### PR TITLE
feat: add --all-platforms/-A option to assemble

### DIFF
--- a/cmd/subcommands/assemble.go
+++ b/cmd/subcommands/assemble.go
@@ -10,6 +10,7 @@ func newAssembleCmd() *cobra.Command {
 	var outputFlag string
 	var branchFlag string
 	var verboseFlag bool
+	var allFlag bool
 
 	cmd := &cobra.Command{
 		Use:   "assemble path-or-git",
@@ -25,10 +26,17 @@ func newAssembleCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&branchFlag, "branch", "b", branchFlag, "Git branch to pull from")
 	assemblyOptions := addAssemblyOptions(cmd)
+	cmd.Flags().BoolVarP(&allFlag, "all-platforms", "A", allFlag, "Generate binaries for all supported platform/arch combinations")
 	cmd.Flags().BoolVarP(&verboseFlag, "verbose", "v", verboseFlag, "Verbose output")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		return assembler.Assemble(args[0], assembler.Options{Name: outputFlag, Branch: branchFlag, Verbose: verboseFlag, AssemblyOptions: *assemblyOptions})
+		return assembler.Assemble(args[0], assembler.Options{
+			Name:            outputFlag,
+			Branch:          branchFlag,
+			Verbose:         verboseFlag,
+			AllPlatforms:    allFlag,
+			AssemblyOptions: *assemblyOptions,
+		})
 	}
 
 	return cmd

--- a/pkg/fe/assembler/options.go
+++ b/pkg/fe/assembler/options.go
@@ -6,5 +6,6 @@ type Options struct {
 	Name            string
 	Branch          string
 	Verbose         bool
+	AllPlatforms    bool
 	AssemblyOptions assembly.Options
 }

--- a/pkg/fe/assembler/platforms.go
+++ b/pkg/fe/assembler/platforms.go
@@ -1,0 +1,15 @@
+package assembler
+
+func supportedOs() []string {
+	return []string{
+		"darwin",
+		"linux",
+	}
+}
+
+func supportedArch() []string {
+	return []string{
+		"amd64",
+		"arm64",
+	}
+}


### PR DESCRIPTION
This is to facilitate building a set of assembled binaries across supported GOOS and GOARCH.