### PR TITLE
fix: update internal minio service name to include 'lunchpail'

### DIFF
--- a/charts/workstealer/templates/containers/workstealer.yaml
+++ b/charts/workstealer/templates/containers/workstealer.yaml
@@ -10,7 +10,7 @@
       prefix: {{ print .Values.taskqueue.dataset "_" }}
 {{- if .Values.internalS3.enabled }}
     - secretRef:
-        name: {{ print (.Release.Name | trunc 50) "-s3" }}
+        name: {{ print (.Release.Name | trunc 40) "-lunchpail-s3" }}
   ports:
     - containerPort: 9000
 {{- end }}

--- a/charts/workstealer/templates/s3/config.yaml
+++ b/charts/workstealer/templates/s3/config.yaml
@@ -1,18 +1,17 @@
 {{- if eq .Values.extract "config" }}
 {{- if .Values.internalS3.enabled }}
 apiVersion: v1
-kind: Secret
+kind: ConfigMap
 metadata:
-  name: {{ print (.Release.Name | trunc 50) "-s3" }}
+  name: {{ print (.Release.Name | trunc 40) "-lunchpail-s3" }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: s3
     app.kubernetes.io/name: {{ .Values.name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: lunchpail.io
-type: Opaque
-stringData:
-  INTERNAL_S3_ACCESS_KEY: {{ .Values.internalS3.accessKey }}
-  INTERNAL_S3_SECRET_KEY: {{ .Values.internalS3.secretKey }}
+data:
+  S3_ENDPOINT: {{ print "http://" .Values.name ":9000" }}
+  USE_MINIO_EXTENSIONS: "true"
 {{- end }}
 {{- end }}

--- a/charts/workstealer/templates/s3/secret.yaml
+++ b/charts/workstealer/templates/s3/secret.yaml
@@ -1,17 +1,18 @@
 {{- if eq .Values.extract "config" }}
 {{- if .Values.internalS3.enabled }}
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
-  name: {{ print (.Values.name | trunc 50) "-s3" }}
+  name: {{ print (.Release.Name | trunc 40) "-lunchpail-s3" }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: s3
     app.kubernetes.io/name: {{ .Values.name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: lunchpail.io
-data:
-  S3_ENDPOINT: {{ print "http://" .Values.name ":9000" }}
-  USE_MINIO_EXTENSIONS: "true"
+type: Opaque
+stringData:
+  INTERNAL_S3_ACCESS_KEY: {{ .Values.internalS3.accessKey }}
+  INTERNAL_S3_SECRET_KEY: {{ .Values.internalS3.secretKey }}
 {{- end }}
 {{- end }}

--- a/charts/workstealer/templates/s3/service.yaml
+++ b/charts/workstealer/templates/s3/service.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ print (.Values.name | trunc 50) "-s3" }}
+  name: {{ print (.Release.Name | trunc 40) "-lunchpail-s3" }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: s3

--- a/pkg/fe/linker/configure.go
+++ b/pkg/fe/linker/configure.go
@@ -83,6 +83,12 @@ func Configure(appname, runname, namespace, templatePath string, internalS3Port 
 	// the app.kubernetes.io/part-of label value
 	partOf := appname
 
+	// see charts/workstealer/templates/s3/service... the hostname of the service has a max length
+	runnameMax40 := runname
+	if len(runname) > 40 {
+		runnameMax40 = runname[:40]
+	}
+
 	yaml := fmt.Sprintf(`
 global:
   type: %s # clusterType (1)
@@ -101,7 +107,7 @@ global:
       create: %v # opts.CreateNamespace (9)
     context:
       name: ""
-  s3Endpoint: http://%s-s3.%s.svc.cluster.local:%d # runname (10) systemNamespace (11) internalS3Port (12)
+  s3Endpoint: http://%s-lunchpail-s3.%s.svc.cluster.local:%d # runnameMax40 (10) systemNamespace (11) internalS3Port (12)
   s3AccessKey: lunchpail
   s3SecretKey: lunchpail
 lunchpail: lunchpail
@@ -145,7 +151,7 @@ lunchpail_internal:
 		systemNamespace,                 // (8)
 		opts.CreateNamespace,            // (9)
 
-		runname,                            // (10)
+		runnameMax40,                       // (10)
 		systemNamespace,                    // (11)
 		internalS3Port,                     // (12)
 		user.Username,                      // (13)

--- a/tests/tests/test7f-repo/preinit.sh
+++ b/tests/tests/test7f-repo/preinit.sh
@@ -1,13 +1,11 @@
-if ! grep rcloneremotetest ~/.config/rclone/rclone.conf
-then
-    cat <<'EOF' >> ~/.config/rclone/rclone.conf 
+rclone config delete rcloneremotetest
+cat <<'EOF' >> ~/.config/rclone/rclone.conf 
 [rcloneremotetest]
 type = s3
 provider = Other
 env_auth = false
-endpoint = http://$TEST_RUN-s3.test7f.svc.cluster.local:$TEST_PORT
+endpoint = http://$TEST_RUN-lunchpail-s3.test7f.svc.cluster.local:$TEST_PORT
 access_key_id = $TEST_ACCESSKEY
 secret_access_key = $TEST_SECRETKEY
 acl = public-read
 EOF
-fi

--- a/tests/tests/test7f/preinit.sh
+++ b/tests/tests/test7f/preinit.sh
@@ -1,13 +1,11 @@
-if ! grep rcloneremotetest ~/.config/rclone/rclone.conf
-then
-    cat <<'EOF' >> ~/.config/rclone/rclone.conf 
+rclone config delete rcloneremotetest
+cat <<'EOF' >> ~/.config/rclone/rclone.conf 
 [rcloneremotetest]
 type = s3
 provider = Other
 env_auth = false
-endpoint = http://$TEST_RUN-s3.test7f.svc.cluster.local:$TEST_PORT
+endpoint = http://$TEST_RUN-lunchpail-s3.test7f.svc.cluster.local:$TEST_PORT
 access_key_id = $TEST_ACCESSKEY
 secret_access_key = $TEST_SECRETKEY
 acl = public-read
 EOF
-fi


### PR DESCRIPTION
This should help us to distinguish lunchpail-provided internal s3 from application-provided services named "s3". Though we already had the run name in the service name, this should hopefully further help us to distinguish *our* service.

Also fixes test7f/preinit.sh, which didn't handle the case where the `rcloneremotetest` config had changed. Also refactors the workstealer chart to place some of the s3 bits under a subdirectory.