### PR TITLE
feat: up --target-platform/-p -> --target/-t

### DIFF
--- a/cmd/subcommands/up.go
+++ b/cmd/subcommands/up.go
@@ -25,7 +25,7 @@ func addAssemblyOptions(cmd *cobra.Command) *assembly.Options {
 	cmd.Flags().StringVarP(&options.DockerHost, "docker-host", "d", "", "[Advanced] Hostname/IP address of docker host")
 
 	cmd.Flags().StringVarP(&options.ApiKey, "api-key", "a", "", "IBM Cloud api key")
-	cmd.Flags().VarP(&options.TargetPlatform, "target-platform", "p", "Backend platform for deploying lunchpail [Kubernetes, IBMCloud, Skypilot]")
+	cmd.Flags().VarP(&options.TargetPlatform, "target", "t", "Deployment target [Kubernetes, IBMCloud, Skypilot]")
 	cmd.Flags().StringVarP(&options.ResourceGroupID, "resource-group-id", "", "", "Identifier of a Cloud resource group to contain the instance(s)")
 	//Todo: allow selecting existing ssh key?
 	cmd.Flags().StringVarP(&options.SSHKeyType, "ssh-key-type", "", "rsa", "SSH key type [rsa, ed25519]")


### PR DESCRIPTION
We previously hadn't used `-t` as it had been a shorthand for `--openshift`. However, #60 removed that option in favor of inferring it (i.e. determining whether the target is openshift automatically, for the user)