### PR TITLE
feat: allow for re-assembly i.e. `assemble` against an assembled binary

### DIFF
--- a/cmd/subcommands/assemble.go
+++ b/cmd/subcommands/assemble.go
@@ -13,10 +13,10 @@ func newAssembleCmd() *cobra.Command {
 	var allFlag bool
 
 	cmd := &cobra.Command{
-		Use:   "assemble path-or-git",
+		Use:   "assemble [path-or-git]",
 		Short: "Generate a binary specialized to a given application",
 		Long:  "Generate a binary specialized to a given application",
-		Args:  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+		Args:  cobra.MatchAll(cobra.MaximumNArgs(1), cobra.OnlyValidArgs),
 	}
 
 	cmd.Flags().StringVarP(&outputFlag, "output", "o", "", "Path to store output binary")
@@ -30,7 +30,12 @@ func newAssembleCmd() *cobra.Command {
 	cmd.Flags().BoolVarP(&verboseFlag, "verbose", "v", verboseFlag, "Verbose output")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		return assembler.Assemble(args[0], assembler.Options{
+		sourcePath := ""
+		if len(args) >= 1 {
+			sourcePath = args[0]
+		}
+
+		return assembler.Assemble(sourcePath, assembler.Options{
 			Name:            outputFlag,
 			Branch:          branchFlag,
 			Verbose:         verboseFlag,

--- a/pkg/fe/assembler/assemble.go
+++ b/pkg/fe/assembler/assemble.go
@@ -63,7 +63,10 @@ func Assemble(sourcePath string, opts Options) error {
 	}
 
 	// TODO... how do we really want to get a good name for the app?
-	assemblyName := filepath.Base(trimExt(sourcePath))
+	assemblyName := assembly.Name()
+	if sourcePath != "" {
+		assemblyName = filepath.Base(trimExt(sourcePath))
+	}
 	if assemblyName == "pail" {
 		assemblyName = filepath.Base(filepath.Dir(trimExt(sourcePath)))
 		if assemblyName == "pail" {

--- a/pkg/fe/assembler/stage.go
+++ b/pkg/fe/assembler/stage.go
@@ -167,7 +167,7 @@ type StageOptions struct {
 
 // return (templatePath, appVersion, error)
 func StagePath(appname, sourcePath string, opts StageOptions) (string, string, error) {
-	appVersion := ""
+	appVersion := assembly.AppVersion()
 
 	templatePath, err := StageTemplate()
 	if err != nil {

--- a/tests/bin/deploy-tests.sh
+++ b/tests/bin/deploy-tests.sh
@@ -67,11 +67,17 @@ repo_secret="" # e.g. user:pat@https://github.mycompany.com
 # final value, and some critical values to bogus values that are then
 # overridden by final values at shrinkwrap time
 /tmp/lunchpail assemble -v \
-               -o $testapp \
-               --create-namespace \
+               -o $testapp.tmp \
                $branch \
                $repo_secret \
                $2
+
+# test coverage for re-assemble
+$testapp.tmp assemble -v \
+             -o $testapp \
+             --create-namespace
+
+rm -f $testapp.tmp
 
 if [[ -d "$2" ]] && [[ -f "$2"/version ]]
 then


### PR DESCRIPTION
Fixes #68 

Closes #67 
In contrast to #67, this PR keeps source as a positional parameter. Adds test coverage.