### PR TITLE
fix: clean up workstealer queue variables

### DIFF
--- a/charts/workstealer/src/workstealer.sh
+++ b/charts/workstealer/src/workstealer.sh
@@ -3,8 +3,6 @@
 SCRIPTDIR=$(cd $(dirname "$0") && pwd)
 
 LOCAL_QUEUE_ROOT=$(mktemp -d /tmp/localqueue.XXXXXXXX)
-QUEUE_BUCKET=${!TASKQUEUE_VAR}
-QUEUE_PATH=$QUEUE_BUCKET/$LUNCHPAIL/$RUN_NAME
 export QUEUE=$LOCAL_QUEUE_ROOT/$QUEUE_PATH
 
 remote=s3:/$QUEUE_PATH
@@ -12,7 +10,7 @@ remote=s3:/$QUEUE_PATH
 S3_ENDPOINT=http://localhost:9000
 
 if [[ -z "$MINIO_ENABLED" ]]
-then S3_ENDPOINT=${!S3_ENDPOINT_VAR}
+then S3_ENDPOINT=$lunchpail_queue_endpoint
 fi
 
 # the rclone.conf file
@@ -24,8 +22,8 @@ type = s3
 provider = Other
 env_auth = false
 endpoint = $S3_ENDPOINT
-access_key_id = ${!AWS_ACCESS_KEY_ID_VAR}
-secret_access_key = ${!AWS_SECRET_ACCESS_KEY_VAR}
+access_key_id = $lunchpail_queue_accessKeyID
+secret_access_key = $lunchpail_queue_secretAccessKey
 acl = public-read
 EOF
 

--- a/charts/workstealer/templates/containers/workstealer.yaml
+++ b/charts/workstealer/templates/containers/workstealer.yaml
@@ -7,7 +7,7 @@
   envFrom:
     - secretRef:
         name: {{ .Values.taskqueue.dataset }}
-      prefix: {{ print .Values.taskqueue.dataset "_" }}
+      prefix: {{ print .Values.lunchpail "_queue_" }}
 {{- if .Values.internalS3.enabled }}
     - secretRef:
         name: {{ print (.Release.Name | trunc 40) "-lunchpail-s3" }}
@@ -29,14 +29,8 @@
       value: {{ .Values.outbox | default "outbox" }}
     - name: WORKER_QUEUES_SUBDIR
       value: queues
-    - name: S3_ENDPOINT_VAR
-      value: {{ print .Values.taskqueue.dataset "_endpoint" }}
-    - name: AWS_ACCESS_KEY_ID_VAR
-      value: {{ print .Values.taskqueue.dataset "_accessKeyID" }}
-    - name: AWS_SECRET_ACCESS_KEY_VAR
-      value: {{ print .Values.taskqueue.dataset "_secretAccessKey" }}
-    - name: TASKQUEUE_VAR
-      value: {{ print .Values.taskqueue.dataset "_bucket" }}
-    - name: LUNCHPAIL
-      value: {{ .Values.lunchpail }}
+    - name: QUEUE_BUCKET
+      value: {{ .Values.taskqueue.bucket }}
+    - name: QUEUE_PATH
+      value: {{ print .Values.taskqueue.bucket "/" .Values.lunchpail "/" .Values.name }}
 {{- end }}


### PR DESCRIPTION
this removes the double indirection `${!variable}` that was confusing and also required bash rather than dash (which is often /bin/sh)