### PR TITLE
fix: begin consolidation of queue prefix path logic

### DIFF
--- a/charts/workstealer/src/workstealer.sh
+++ b/charts/workstealer/src/workstealer.sh
@@ -71,7 +71,7 @@ idx=1
 # We will do an B/A comparison (Before/After) of the queue files
 B=$(mktemp /tmp/before.$idx.XXXXXXXXXXXX)
 
-rclone mkdir s3:$QUEUE_BUCKET
+rclone mkdir s3:$QUEUE_PATH
 
 # to future porters of this to e.g. go... this /tmp/done is only to
 # work around bash's inability for the whle read line below to cleanly

--- a/charts/workstealer/templates/containers/workstealer.yaml
+++ b/charts/workstealer/templates/containers/workstealer.yaml
@@ -7,7 +7,7 @@
   envFrom:
     - secretRef:
         name: {{ .Values.taskqueue.dataset }}
-      prefix: {{ print .Values.lunchpail "_queue_" }}
+      prefix: lunchpail_queue_
 {{- if .Values.internalS3.enabled }}
     - secretRef:
         name: {{ print (.Release.Name | trunc 40) "-lunchpail-s3" }}
@@ -29,8 +29,6 @@
       value: {{ .Values.outbox | default "outbox" }}
     - name: WORKER_QUEUES_SUBDIR
       value: queues
-    - name: QUEUE_BUCKET
-      value: {{ .Values.taskqueue.bucket }}
     - name: QUEUE_PATH
-      value: {{ print .Values.taskqueue.bucket "/" .Values.lunchpail "/" .Values.name }}
+      value: {{ .Values.taskqueue.prefixPath }}
 {{- end }}

--- a/pkg/fe/transformer/api/queue.go
+++ b/pkg/fe/transformer/api/queue.go
@@ -1,0 +1,12 @@
+package api
+
+import (
+	"path/filepath"
+
+	"lunchpail.io/pkg/fe/linker/queue"
+)
+
+// path in s3 to store the queue for the given run
+func QueuePrefixPath(queueSpec queue.Spec, runname string) string {
+	return filepath.Join(queueSpec.Bucket, "lunchpail", runname)
+}

--- a/pkg/fe/transformer/api/workstealer/lower.go
+++ b/pkg/fe/transformer/api/workstealer/lower.go
@@ -11,7 +11,6 @@ import (
 	"lunchpail.io/pkg/ir/hlir"
 	"lunchpail.io/pkg/ir/llir"
 	"lunchpail.io/pkg/lunchpail"
-	comp "lunchpail.io/pkg/lunchpail"
 )
 
 func Lower(assemblyName, runname, namespace string, app hlir.Application, queueSpec queue.Spec, repoSecrets []hlir.RepoSecret, opts assembly.Options, verbose bool) (llir.Component, error) {
@@ -43,6 +42,7 @@ func Lower(assemblyName, runname, namespace string, app hlir.Application, queueS
 		"taskqueue.bucket=" + queueSpec.Bucket,
 		"taskqueue.accessKey=" + queueSpec.AccessKey,
 		"taskqueue.secretKey=" + queueSpec.SecretKey,
+		"taskqueue.prefixPath=" + api.QueuePrefixPath(queueSpec, runname),
 		"sleep_before_exit=" + os.Getenv("LP_SLEEP_BEFORE_EXIT"),
 	}
 
@@ -50,5 +50,5 @@ func Lower(assemblyName, runname, namespace string, app hlir.Application, queueS
 		fmt.Fprintf(os.Stderr, "Workstealer values\n%s\n", "\n  -"+strings.Join(values, "\n  - "))
 	}
 
-	return api.GenerateComponent(runname, namespace, templatePath, values, verbose, comp.WorkStealerComponent)
+	return api.GenerateComponent(runname, namespace, templatePath, values, verbose, lunchpail.WorkStealerComponent)
 }


### PR DESCRIPTION
See pkg/fe/transformer/api/queue.go

Starting with the workstealer. This also continues #81 to clean up workstealer shell variables even further.