### PR TITLE
fix: continue consolidate of queue variables

### DIFF
--- a/charts/shell/templates/containers/main.yaml
+++ b/charts/shell/templates/containers/main.yaml
@@ -17,13 +17,13 @@
     - name: WORKQUEUE
       value: /queue
     - name: S3_ENDPOINT_VAR
-      value: {{ print .Values.queue.dataset "_endpoint" }}
+      value: lunchpail_queue_endpoint
     - name: AWS_ACCESS_KEY_ID_VAR
-      value: {{ print .Values.queue.dataset "_accessKeyID" }}
+      value: lunchpail_queue_accessKeyID
     - name: AWS_SECRET_ACCESS_KEY_VAR
-      value: {{ print .Values.queue.dataset "_secretAccessKey" }}
+      value: lunchpail_queue_secretAccessKey
     - name: TASKQUEUE_VAR
-      value: {{ print .Values.queue.dataset "_bucket" }}
+      value: lunchpail_queue_bucket
     - name: LUNCHPAIL
       value: lunchpail
   {{- if .Values.containerSecurityContext }}

--- a/charts/workerpool/templates/queue.yaml
+++ b/charts/workerpool/templates/queue.yaml
@@ -9,13 +9,13 @@
 
 {{- define "queue/env/dataset" }}
 - name: S3_ENDPOINT_VAR
-  value: {{ print .Values.queue.dataset "_endpoint" }}
+  value: lunchpail_queue_endpoint
 - name: AWS_ACCESS_KEY_ID_VAR
-  value: {{ print .Values.queue.dataset "_accessKeyID" }}
+  value: lunchpail_queue_accessKeyID
 - name: AWS_SECRET_ACCESS_KEY_VAR
-  value: {{ print .Values.queue.dataset "_secretAccessKey" }}
+  value: lunchpail_queue_secretAccessKey
 - name: TASKQUEUE_VAR
-  value: {{ print .Values.queue.dataset "_bucket" }}
+  value: lunchpail_queue_bucket
 - name: LUNCHPAIL
   value: {{ .Values.lunchpail }}
 {{- end }}

--- a/images/components/lunchpail-worker-watcher/main.go
+++ b/images/components/lunchpail-worker-watcher/main.go
@@ -18,6 +18,9 @@ import (
 )
 
 func main() {
+	// helpful for debugging
+	fmt.Println(os.Environ())
+
 	client, err := newClient()
 	if err != nil {
 		log.Panic(err)

--- a/pkg/fe/transformer/api/datasets.go
+++ b/pkg/fe/transformer/api/datasets.go
@@ -41,12 +41,13 @@ type secretRef struct {
 }
 
 type envFrom struct {
+	// The secret that stores the environment variables we wish to
+	// bind to a worker
 	SecretRef secretRef `json:"secretRef"`
-	Prefix    string    `json:"prefix,omitempty"`
-}
 
-func envForQueue(queueSpec queue.Spec) envFrom {
-	return envFrom{secretRef{queueSpec.Name}, queueSpec.Name + "_"}
+	// Prefix string for environment variables bound to the values
+	// in the referenced secret
+	Prefix string `json:"prefix,omitempty"`
 }
 
 func datasets(app hlir.Application, queueSpec queue.Spec) ([]volume, []volumeMount, []envFrom, []initContainer, error) {

--- a/pkg/fe/transformer/api/queue.go
+++ b/pkg/fe/transformer/api/queue.go
@@ -6,7 +6,15 @@ import (
 	"lunchpail.io/pkg/fe/linker/queue"
 )
 
-// path in s3 to store the queue for the given run
+// Path in s3 to store the queue for the given run
 func QueuePrefixPath(queueSpec queue.Spec, runname string) string {
 	return filepath.Join(queueSpec.Bucket, "lunchpail", runname)
+}
+
+// Inject queue secrets
+func envForQueue(queueSpec queue.Spec) envFrom {
+	return envFrom{
+		Prefix:    "lunchpail_queue_",
+		SecretRef: secretRef{queueSpec.Name},
+	}
 }

--- a/pkg/fe/transformer/api/shell/lower.go
+++ b/pkg/fe/transformer/api/shell/lower.go
@@ -12,7 +12,6 @@ import (
 	"lunchpail.io/pkg/ir/hlir"
 	"lunchpail.io/pkg/ir/llir"
 	"lunchpail.io/pkg/lunchpail"
-	comp "lunchpail.io/pkg/lunchpail"
 	"lunchpail.io/pkg/util"
 )
 
@@ -71,7 +70,6 @@ func Lower(assemblyName, runname, namespace string, app hlir.Application, queueS
 		"volumeMounts=" + volumeMounts,
 		"envFroms=" + envFroms,
 		"env=" + env,
-		"queue.dataset=" + queueSpec.Name,
 		"mcad.enabled=false",
 		"rbac.runAsRoot=false",
 		"rbac.serviceaccount=" + runname,
@@ -95,5 +93,5 @@ func Lower(assemblyName, runname, namespace string, app hlir.Application, queueS
 		fmt.Fprintf(os.Stderr, "Shell values\n%s\n", strings.Replace(strings.Join(values, "\n  - "), workdirCmData, "", 1))
 	}
 
-	return api.GenerateComponent(runname, namespace, templatePath, values, verbose, comp.DispatcherComponent)
+	return api.GenerateComponent(runname, namespace, templatePath, values, verbose, lunchpail.DispatcherComponent)
 }

--- a/pkg/fe/transformer/api/workerpool/lower.go
+++ b/pkg/fe/transformer/api/workerpool/lower.go
@@ -79,7 +79,6 @@ func Lower(assemblyName, runname, namespace string, app hlir.Application, pool h
 		"workers.memory=" + sizing.Memory,
 		"workers.gpu=" + strconv.Itoa(sizing.Gpu),
 		"lunchpail=lunchpail",
-		"queue.dataset=" + queueSpec.Name,
 		"volumes=" + volumes,
 		"volumeMounts=" + volumeMounts,
 		"envFroms=" + envFroms,


### PR DESCRIPTION
This continues the work of #81 and #82 to consolidate the queue variables. This extends to ensure that all envs use the same variable prefix naming scheme, from shell to workerpool to workstealer.