### PR TITLE
fix: clean up workerpool and shell queue variables

### DIFF
--- a/charts/shell/prestop.sh
+++ b/charts/shell/prestop.sh
@@ -3,16 +3,16 @@
 echo "DEBUG prestop starting"
 
 config=/tmp/rclone-prestop.conf
-donefile=s3:/${!TASKQUEUE_VAR}/$LUNCHPAIL/$RUN_NAME/done
+donefile=s3:/$LUNCHPAIL_QUEUE_PATH/done
 
 cat <<EOF > $config
 [s3]
 type = s3
 provider = Other
 env_auth = false
-endpoint = ${!S3_ENDPOINT_VAR}
-access_key_id = ${!AWS_ACCESS_KEY_ID_VAR}
-secret_access_key = ${!AWS_SECRET_ACCESS_KEY_VAR}
+endpoint = $lunchpail_queue_endpoint
+access_key_id = $lunchpail_queue_accessKeyID
+secret_access_key = $lunchpail_queue_secretAccessKey
 acl = public-read
 EOF
 

--- a/charts/shell/templates/containers/main.yaml
+++ b/charts/shell/templates/containers/main.yaml
@@ -16,16 +16,8 @@
       value: {{ .Values.name }}
     - name: WORKQUEUE
       value: /queue
-    - name: S3_ENDPOINT_VAR
-      value: lunchpail_queue_endpoint
-    - name: AWS_ACCESS_KEY_ID_VAR
-      value: lunchpail_queue_accessKeyID
-    - name: AWS_SECRET_ACCESS_KEY_VAR
-      value: lunchpail_queue_secretAccessKey
-    - name: TASKQUEUE_VAR
-      value: lunchpail_queue_bucket
-    - name: LUNCHPAIL
-      value: lunchpail
+    - name: LUNCHPAIL_QUEUE_PATH
+      value: {{ .Values.taskqueue.prefixPath }}
   {{- if .Values.containerSecurityContext }}
   securityContext: {{ .Values.containerSecurityContext | b64dec | fromYaml | toJson }}
   {{- end }}

--- a/charts/workerpool/templates/containers/app.yaml
+++ b/charts/workerpool/templates/containers/app.yaml
@@ -10,7 +10,7 @@
   env:
     - name: LUNCHPAIL_STARTUP_DELAY
       value: {{ .Values.startupDelay | default 0 | quote }}
-    - name: POD_NAME
+    - name: LUNCHPAIL_POD_NAME
       valueFrom:
         fieldRef:
           fieldPath: metadata.name

--- a/charts/workerpool/templates/queue.yaml
+++ b/charts/workerpool/templates/queue.yaml
@@ -1,23 +1,13 @@
 {{- define "queue/env" }}
-- name: WORKQUEUE
+- name: LUNCHPAIL_LOCAL_QUEUE_ROOT
   value: /queue
-- name: POOL
-  value: {{ print .Release.Name | trunc 53 }} # workerpool name
-- name: RUN_NAME
+- name: LUNCHPAIL_RUN_NAME
   value: {{ .Values.runName }} # name of run in which this pool participates
 {{- end }}
 
 {{- define "queue/env/dataset" }}
-- name: S3_ENDPOINT_VAR
-  value: lunchpail_queue_endpoint
-- name: AWS_ACCESS_KEY_ID_VAR
-  value: lunchpail_queue_accessKeyID
-- name: AWS_SECRET_ACCESS_KEY_VAR
-  value: lunchpail_queue_secretAccessKey
-- name: TASKQUEUE_VAR
-  value: lunchpail_queue_bucket
-- name: LUNCHPAIL
-  value: {{ .Values.lunchpail }}
+- name: LUNCHPAIL_QUEUE_PATH
+  value: {{ .Values.taskqueue.prefixPath }}
 {{- end }}
 
 {{- define "queue/volumeMount" }}

--- a/charts/workstealer/src/workstealer.sh
+++ b/charts/workstealer/src/workstealer.sh
@@ -3,9 +3,9 @@
 SCRIPTDIR=$(cd $(dirname "$0") && pwd)
 
 LOCAL_QUEUE_ROOT=$(mktemp -d /tmp/localqueue.XXXXXXXX)
-export QUEUE=$LOCAL_QUEUE_ROOT/$QUEUE_PATH
+export QUEUE=$LOCAL_QUEUE_ROOT/$LUNCHPAIL_QUEUE_PATH
 
-remote=s3:/$QUEUE_PATH
+remote=s3:/$LUNCHPAIL_QUEUE_PATH
 
 S3_ENDPOINT=http://localhost:9000
 
@@ -71,7 +71,7 @@ idx=1
 # We will do an B/A comparison (Before/After) of the queue files
 B=$(mktemp /tmp/before.$idx.XXXXXXXXXXXX)
 
-rclone mkdir s3:$QUEUE_PATH
+rclone mkdir $remote
 
 # to future porters of this to e.g. go... this /tmp/done is only to
 # work around bash's inability for the whle read line below to cleanly

--- a/charts/workstealer/templates/containers/workstealer.yaml
+++ b/charts/workstealer/templates/containers/workstealer.yaml
@@ -29,6 +29,6 @@
       value: {{ .Values.outbox | default "outbox" }}
     - name: WORKER_QUEUES_SUBDIR
       value: queues
-    - name: QUEUE_PATH
+    - name: LUNCHPAIL_QUEUE_PATH
       value: {{ .Values.taskqueue.prefixPath }}
 {{- end }}

--- a/pkg/fe/transformer/api/dispatch/parametersweep/main.sh
+++ b/pkg/fe/transformer/api/dispatch/parametersweep/main.sh
@@ -23,15 +23,15 @@ then printenv
 fi
 
 config=/tmp/rclone.conf
-remote=s3:/${!TASKQUEUE_VAR}/$LUNCHPAIL/$RUN_NAME/inbox
+remote=s3:/${LUNCHPAIL_QUEUE_PATH}/inbox
 cat <<EOF > $config
 [s3]
 type = s3
 provider = Other
 env_auth = false
-endpoint = ${!S3_ENDPOINT_VAR}
-access_key_id = ${!AWS_ACCESS_KEY_ID_VAR}
-secret_access_key = ${!AWS_SECRET_ACCESS_KEY_VAR}
+endpoint = $lunchpail_queue_endpoint
+access_key_id = $lunchpail_queue_accessKeyID
+secret_access_key = $lunchpail_queue_secretAccessKey
 acl = public-read
 EOF
 

--- a/pkg/fe/transformer/api/dispatch/s3/main.sh
+++ b/pkg/fe/transformer/api/dispatch/s3/main.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 printenv
 
 config=/tmp/rclone.conf
-remote=queue:/${!TASKQUEUE_VAR}/$LUNCHPAIL/$RUN_NAME/inbox
+remote=queue:/$LUNCHPAIL_QUEUE_PATH/inbox
 
 echo "ProcessS3Objects dispatcher starting up. Using remote=$remote and processing bucket=$__LUNCHPAIL_PROCESS_S3_OBJECTS_PATH"
 
@@ -23,9 +23,9 @@ acl = public-read
 type = s3
 provider = Other
 env_auth = false
-endpoint = ${!S3_ENDPOINT_VAR}
-access_key_id = ${!AWS_ACCESS_KEY_ID_VAR}
-secret_access_key = ${!AWS_SECRET_ACCESS_KEY_VAR}
+endpoint = $lunchpail_queue_endpoint
+access_key_id = $lunchpail_queue_accessKeyID
+secret_access_key = $lunchpail_queue_secretAccessKey
 acl = public-read
 EOF
 
@@ -47,7 +47,7 @@ do
         do
             ext=${task##*.}
             remote_task="${task%.*}.$i.$ext"
-            echo "Injecting task=$task as remote_task=$remote_task"
+            echo "Injecting task=$task as remote_task=$remote/$remote_task"
             rclone --config $config copyto origin:$__LUNCHPAIL_PROCESS_S3_OBJECTS_PATH/$task $remote/$remote_task
         done
     done

--- a/pkg/fe/transformer/api/queue.go
+++ b/pkg/fe/transformer/api/queue.go
@@ -11,6 +11,14 @@ func QueuePrefixPath(queueSpec queue.Spec, runname string) string {
 	return filepath.Join(queueSpec.Bucket, "lunchpail", runname)
 }
 
+// Path in s3 to store the queue data for a particular worker in a
+// particular pool for a particular run. Note how we need to defer the
+// worker name until run time, which we do via a
+// $LUNCHPAIL_WORKER_NAME env var.
+func QueuePrefixPathForWorker(queueSpec queue.Spec, runname, poolName string) string {
+	return filepath.Join(QueuePrefixPath(queueSpec, runname), "queues", poolName+".$LUNCHPAIL_WORKER_NAME")
+}
+
 // Inject queue secrets
 func envForQueue(queueSpec queue.Spec) envFrom {
 	return envFrom{

--- a/pkg/fe/transformer/api/shell/lower.go
+++ b/pkg/fe/transformer/api/shell/lower.go
@@ -70,6 +70,7 @@ func Lower(assemblyName, runname, namespace string, app hlir.Application, queueS
 		"volumeMounts=" + volumeMounts,
 		"envFroms=" + envFroms,
 		"env=" + env,
+		"taskqueue.prefixPath=" + api.QueuePrefixPath(queueSpec, runname),
 		"mcad.enabled=false",
 		"rbac.runAsRoot=false",
 		"rbac.serviceaccount=" + runname,

--- a/pkg/fe/transformer/api/workerpool/lower.go
+++ b/pkg/fe/transformer/api/workerpool/lower.go
@@ -79,6 +79,7 @@ func Lower(assemblyName, runname, namespace string, app hlir.Application, pool h
 		"workers.memory=" + sizing.Memory,
 		"workers.gpu=" + strconv.Itoa(sizing.Gpu),
 		"lunchpail=lunchpail",
+		"taskqueue.prefixPath=" + api.QueuePrefixPathForWorker(queueSpec, runname, pool.Metadata.Name),
 		"volumes=" + volumes,
 		"volumeMounts=" + volumeMounts,
 		"envFroms=" + envFroms,


### PR DESCRIPTION
This continues #81 #82 #83 by consolidating the queue variables for the workerpool and shell components.