### PR TITLE
fix: clean up handling of queue paths

### DIFF
--- a/charts/workerpool/templates/job.yaml
+++ b/charts/workerpool/templates/job.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/component: workerpool
     app.kubernetes.io/part-of: {{ .Values.partOf }}
-    app.kubernetes.io/name: {{ print .Release.Name | trunc 53 }}
+    app.kubernetes.io/name: {{ .Values.lunchpail.poolName }}
     app.kubernetes.io/instance: {{ .Values.runName }}
     app.kubernetes.io/managed-by: lunchpail.io
 spec:
@@ -19,7 +19,7 @@ spec:
       labels:
         app.kubernetes.io/component: workerpool
         app.kubernetes.io/part-of: {{ .Values.partOf }}
-        app.kubernetes.io/name: {{ print .Release.Name | trunc 53 }}
+        app.kubernetes.io/name: {{ .Values.lunchpail.poolName }}
         app.kubernetes.io/instance: {{ .Values.runName }}
         app.kubernetes.io/managed-by: lunchpail.io
     spec:

--- a/images/components/lunchpail-worker-watcher/main.go
+++ b/images/components/lunchpail-worker-watcher/main.go
@@ -34,7 +34,7 @@ func main() {
 
 	fullPrefix := strings.Split(os.Getenv("LUNCHPAIL_QUEUE_PATH"), "/")
 	bucket := fullPrefix[0]
-	prefix := strings.Replace(filepath.Join(fullPrefix[1:]...), "$LUNCHPAIL_WORKER_NAME", getPodNameSuffix(os.Getenv("LUNCHPAIL_POD_NAME")), 1)
+	prefix := strings.Replace(filepath.Join(fullPrefix[1:]...), "$LUNCHPAIL_WORKER_NAME", os.Getenv("LUNCHPAIL_POD_NAME"), 1)
 	remote := filepath.Join(bucket, prefix)
 	inbox := "inbox"
 	processing := "processing"
@@ -215,12 +215,6 @@ func startWatch(handler []string, client *minio.Client, bucket, prefix, remote, 
 	}
 
 	fmt.Println("DEBUG Worker exiting normally")
-}
-
-func getPodNameSuffix(podName string) string {
-	// use pod name suffix hash from batch.v1/Job controller
-	parts := strings.Split(podName, "-")
-	return parts[len(parts)-1]
 }
 
 func lsf(client *minio.Client, bucket, prefix string) ([]string, error) {

--- a/pkg/fe/transformer/api/queue.go
+++ b/pkg/fe/transformer/api/queue.go
@@ -1,7 +1,9 @@
 package api
 
 import (
+	"fmt"
 	"path/filepath"
+	"strings"
 
 	"lunchpail.io/pkg/fe/linker/queue"
 )
@@ -11,12 +13,33 @@ func QueuePrefixPath(queueSpec queue.Spec, runname string) string {
 	return filepath.Join(queueSpec.Bucket, "lunchpail", runname)
 }
 
+// The queue path for a worker that specifies the pool name and the worker name
+func QueueSubPathForWorker(poolName, workerName string) string {
+	return filepath.Join(poolName, workerName)
+}
+
+// Opposite of `QueueSubPathForWorker`, e.g. test7f-pool1/w96bh -> (test7f-pool1,w96bh)
+func ExtractNamesFromSubPathForWorker(combo string) (poolName string, workerName string, err error) {
+	if idx := strings.Index(combo, "/"); idx < 0 {
+		// TODO error handling here. what do we want to do?
+		err = fmt.Errorf("Invalid subpath %s", combo)
+	} else {
+		poolName = combo[:idx]
+		workerName = combo[idx+1:]
+	}
+	return
+}
+
 // Path in s3 to store the queue data for a particular worker in a
 // particular pool for a particular run. Note how we need to defer the
 // worker name until run time, which we do via a
 // $LUNCHPAIL_WORKER_NAME env var.
 func QueuePrefixPathForWorker(queueSpec queue.Spec, runname, poolName string) string {
-	return filepath.Join(QueuePrefixPath(queueSpec, runname), "queues", poolName+".$LUNCHPAIL_WORKER_NAME")
+	return filepath.Join(
+		QueuePrefixPath(queueSpec, runname),
+		"queues",
+		QueueSubPathForWorker(poolName, "$LUNCHPAIL_WORKER_NAME"),
+	)
 }
 
 // Inject queue secrets

--- a/pkg/fe/transformer/api/workerpool/lower.go
+++ b/pkg/fe/transformer/api/workerpool/lower.go
@@ -78,7 +78,7 @@ func Lower(assemblyName, runname, namespace string, app hlir.Application, pool h
 		"workers.cpu=" + sizing.Cpu,
 		"workers.memory=" + sizing.Memory,
 		"workers.gpu=" + strconv.Itoa(sizing.Gpu),
-		"lunchpail=lunchpail",
+		"lunchpail.poolName=" + pool.Metadata.Name,
 		"taskqueue.prefixPath=" + api.QueuePrefixPathForWorker(queueSpec, runname, pool.Metadata.Name),
 		"volumes=" + volumes,
 		"volumeMounts=" + volumeMounts,


### PR DESCRIPTION
We had been doing some ugly implicit logic about how to specify and intuit queue filepaths w.r.t. pool name and worker name. This simplifies that all and consolidates the logic further into api/queue.go.