### PR TITLE
feat: log qstat info to a file in the queue folder

### DIFF
--- a/pkg/be/kubernetes/shell/chart/templates/containers/main.yaml
+++ b/pkg/be/kubernetes/shell/chart/templates/containers/main.yaml
@@ -15,6 +15,10 @@
   env:
     - name: LUNCHPAIL_QUEUE_PATH
       value: {{ .Values.taskqueue.prefixPath }}
+    {{- if .Values.lunchpail.debug }}
+    - name: DEBUG
+      value: "true"
+    {{- end }}
     - name: LUNCHPAIL_POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/be/kubernetes/shell/template.go
+++ b/pkg/be/kubernetes/shell/template.go
@@ -56,6 +56,7 @@ func Template(ir llir.LLIR, c llir.ShellComponent, namespace string, opts common
 		"image=" + c.Application.Spec.Image,
 		"command=" + c.Application.Spec.Command,
 		fmt.Sprintf("lunchpail.runAsJob=%v", c.RunAsJob),
+		fmt.Sprintf("lunchpail.debug=%v", verbose),
 		"lunchpail.terminationGracePeriodSeconds=" + strconv.Itoa(terminationGracePeriodSeconds),
 		"workers.count=" + strconv.Itoa(c.Sizing.Workers),
 		"workers.cpu=" + c.Sizing.Cpu,

--- a/pkg/runtime/workstealer/run.go
+++ b/pkg/runtime/workstealer/run.go
@@ -13,6 +13,7 @@ import (
 var debug = os.Getenv("DEBUG") != ""
 var run = os.Getenv("LUNCHPAIL_RUN_NAME")
 var queue = os.Getenv("LUNCHPAIL_QUEUE_PATH")
+var logDir = filepath.Join(queue, "logs")
 var inbox = filepath.Join(queue, "inbox")
 var finished = filepath.Join(queue, "finished")
 var outbox = filepath.Join(queue, "outbox")
@@ -71,7 +72,10 @@ func Run() error {
 	for {
 		// fetch model
 		m := c.fetchModel()
-		m.report()
+
+		if err := m.report(c); err != nil {
+			return err
+		}
 
 		// assess it
 		if c.assess(m) {


### PR DESCRIPTION
This should enable clients pulling the info from the queue, rather than having to interact with the cluster logging mechanisms directly.

For now, we continue (also) to log to the qstat stream to stderr, so that the pkg/observe logic doesn't need to change (yet).