### PR TITLE
fix: remove remnants of internal s3 from workstealer chart

### DIFF
--- a/charts/workstealer/templates/containers/workstealer.yaml
+++ b/charts/workstealer/templates/containers/workstealer.yaml
@@ -8,17 +8,7 @@
     - secretRef:
         name: {{ .Values.taskqueue.dataset }}
       prefix: lunchpail_queue_
-{{- if .Values.internalS3.enabled }}
-    - secretRef:
-        name: {{ print (.Release.Name | trunc 40) "-lunchpail-minio" }}
-  ports:
-    - containerPort: 9000
-{{- end }}
   env:
-{{- if .Values.internalS3.enabled }}
-    - name: MINIO_ENABLED
-      value: "yes"
-{{- end }}
     - name: LUNCHPAIL_SLEEP_BEFORE_EXIT # if tests need to capture some output before we exit
       value: {{ .Values.sleep_before_exit | default 0 | quote }}
     - name: LUNCHPAIL_RUN_NAME


### PR DESCRIPTION
This removes some stragglers left behind by #142