### PR TITLE
fix: restructure Dockerfile to avoid proliferation of 1.8Gi image build layers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@
 .git
 *.log
 *~
+*.tar.gz


### PR DESCRIPTION
We were correctly using `go mod download` to cache dependencies in an image layer... but we are also using the hack/setup/cli.sh to build the CLI, which *also* did a go mod download...