### PR TITLE
fix: add sleep before exit in minio and terminationGracePeriodSeconds when running tests

### DIFF
--- a/charts/shell/templates/pod.yaml
+++ b/charts/shell/templates/pod.yaml
@@ -12,10 +12,7 @@ metadata:
     app.kubernetes.io/managed-by: lunchpail.io
 spec:
   restartPolicy: OnFailure
-
-  {{- if eq .Values.component "minio" }}
-  terminationGracePeriodSeconds: 0
-  {{- end }}
+  terminationGracePeriodSeconds: {{ .Values.lunchpail.terminationGracePeriodSeconds | default 0 }}
 
   {{- if .Values.rbac.serviceaccount }}
   serviceAccountName: {{ .Values.rbac.serviceaccount }}

--- a/pkg/fe/transformer/api/minio/minio.sh
+++ b/pkg/fe/transformer/api/minio/minio.sh
@@ -29,3 +29,7 @@ mc mb lunchpail/$LUNCHPAIL_QUEUE_BUCKET
 set -x
 { head -1; kill "$!"; } < <(mc watch lunchpail/$LUNCHPAIL_QUEUE_BUCKET --prefix $LUNCHPAIL_QUEUE_PREFIX/alldone --events put)
 echo "Got all done marker, exiting..."
+
+# Tests may want us to sleep a bit, so they can capture data for
+# validation checks.
+sleep ${LUNCHPAIL_SLEEP_BEFORE_EXIT:-0}

--- a/pkg/fe/transformer/api/minio/transpile.go
+++ b/pkg/fe/transformer/api/minio/transpile.go
@@ -2,6 +2,7 @@ package minio
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -33,6 +34,11 @@ func transpile(runname string, queueSpec queue.Spec) (hlir.Application, error) {
 	app.Spec.Env["USE_MINIO_EXTENSIONS"] = "true"
 	app.Spec.Env["LUNCHPAIL_QUEUE_BUCKET"] = queueSpec.Bucket
 	app.Spec.Env["LUNCHPAIL_QUEUE_PREFIX"] = prefixExcludingBucket
+
+	if os.Getenv("CI") != "" {
+		// Helps with tests. see ./minio.sh
+		app.Spec.Env["LUNCHPAIL_SLEEP_BEFORE_EXIT"] = "5"
+	}
 
 	return app, nil
 }

--- a/pkg/fe/transformer/api/shell/lower.go
+++ b/pkg/fe/transformer/api/shell/lower.go
@@ -63,6 +63,12 @@ func LowerAsComponent(compilationName, runname, namespace string, app hlir.Appli
 		defer os.RemoveAll(templatePath)
 	}
 
+	terminationGracePeriodSeconds := 0
+	if os.Getenv("CI") != "" {
+		// tests may expect to observe output before self-destruction
+		terminationGracePeriodSeconds = 5
+	}
+
 	values := []string{
 		"name=" + runname,
 		"partOf=" + compilationName,
@@ -90,6 +96,7 @@ func LowerAsComponent(compilationName, runname, namespace string, app hlir.Appli
 		"lunchpail.image.registry=" + lunchpail.ImageRegistry,
 		"lunchpail.image.repo=" + lunchpail.ImageRepo,
 		"lunchpail.image.version=" + lunchpail.Version(),
+		"lunchpail.terminationGracePeriodSeconds=" + strconv.Itoa(terminationGracePeriodSeconds),
 	}
 
 	if len(app.Spec.Expose) > 0 {

--- a/pkg/runtime/queue/s3.go
+++ b/pkg/runtime/queue/s3.go
@@ -216,7 +216,10 @@ func (s3 S3Client) Mkdirp(bucket string) error {
 
 	if !exists {
 		if err := s3.client.MakeBucket(context.Background(), bucket, minio.MakeBucketOptions{}); err != nil {
-			return err
+			if !strings.Contains(err.Error(), "Your previous request to create the named bucket succeeded and you already own it") {
+				// bucket already exists error
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
In tests/bin/helpers.sh we try to pull out info about the queue after the test has passed. But minio self-destructs, and prior to this PR, it does so without any termination grace period.