### PR TITLE
refactor: further simplify template values in configure.go

### DIFF
--- a/pkg/fe/linker/configure.go
+++ b/pkg/fe/linker/configure.go
@@ -9,6 +9,7 @@ import (
 	"lunchpail.io/pkg/be"
 	"lunchpail.io/pkg/compilation"
 	"lunchpail.io/pkg/fe/linker/queue"
+	"lunchpail.io/pkg/lunchpail"
 	"lunchpail.io/pkg/util"
 )
 
@@ -94,46 +95,48 @@ func Configure(appname, runname, namespace, templatePath string, internalS3Port 
 	}
 
 	yaml := fmt.Sprintf(`
-global:
-  jaas:
-    ips: %s # imagePullSecretName (3)
+lunchpail:
+  ips:
+    name: %s # imagePullSecretName (3)
     dockerconfigjson: %s # dockerconfigjson (4)
-    namespace:
-      name: %v # systemNamespace (5)
-      create: %v # opts.CreateNamespace (6)
-username: %s # user.Username (10)
-uid: %s # user.Uid (11)
-rbac:
-  serviceaccount: %s # serviceAccount (12)
-partOf: %s # partOf (16)
-taskqueue:
-  auto: %v # queueSpec.Auto (17)
-  dataset: %s # queueSpec.Name (18)
-  endpoint: %s # queueSpec.Endpoint (19)
-  bucket: %s # queueSpec.Bucket (20)
-  accessKey: %s # queueSpec.AccessKey (21)
-  secretKey: %s # queueSpec.SecretKey (22)
+  namespace:
+    create: %v # opts.CreateNamespace (5)
+  rbac:
+    serviceaccount: %s # serviceAccount (6)
+  taskqueue:
+    auto: %v # queueSpec.Auto (17)
+    dataset: %s # queueSpec.Name (18)
+    endpoint: %s # queueSpec.Endpoint (19)
+    bucket: %s # queueSpec.Bucket (20)
+    accessKey: %s # queueSpec.AccessKey (21)
+    secretKey: %s # queueSpec.SecretKey (22)
+  user:
+    name: %s # user.Username (10)
+    uid: %s # user.Uid (11)
+  image:
+    registry: %s # (12)
+    repo: %s # (13)
+    version: %s # (14)
 name: %s # runname (23)
-namespace:
-  user: %s # namespace (24)
+partOf: %s # partOf (16)
 `,
 		imagePullSecretName,                     // (3)
 		dockerconfigjson,                        // (4)
-		systemNamespace,                         // (5)
-		opts.CompilationOptions.CreateNamespace, // (6)
-
-		user.Username,       // (10)
-		user.Uid,            // (11)
-		serviceAccount,      // (12)
-		partOf,              // (16)
-		queueSpec.Auto,      // (17)
-		queueSpec.Name,      // (18)
-		queueSpec.Endpoint,  // (19)
-		queueSpec.Bucket,    // (20)
-		queueSpec.AccessKey, // (21)
-		queueSpec.SecretKey, // (22)
-		runname,             // (23)
-		namespace,           // (24)
+		opts.CompilationOptions.CreateNamespace, // (5)
+		serviceAccount,                          // (6)
+		queueSpec.Auto,                          // (17)
+		queueSpec.Name,                          // (18)
+		queueSpec.Endpoint,                      // (19)
+		queueSpec.Bucket,                        // (20)
+		queueSpec.AccessKey,                     // (21)
+		queueSpec.SecretKey,                     // (22)
+		user.Username,                           // (10)
+		user.Uid,                                // (11)
+		lunchpail.ImageRegistry,                 // (12)
+		lunchpail.ImageRepo,                     // (13)
+		lunchpail.Version(),                     // (14)
+		runname,                                 // (23)
+		partOf,                                  // (16)
 	)
 
 	if opts.Verbose {

--- a/pkg/fe/template/chart/templates/default-queue.yaml
+++ b/pkg/fe/template/chart/templates/default-queue.yaml
@@ -2,14 +2,14 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.taskqueue.dataset }}
-  namespace: {{ .Values.namespace.user }}
+  name: {{ .Values.lunchpail.taskqueue.dataset }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: taskqueue
     app.kubernetes.io/instance: {{ .Release.Name }}
 type: Opaque
 stringData:
-  bucket: {{ .Values.taskqueue.bucket }}
-  endpoint: {{ .Values.taskqueue.endpoint }}
-  accessKeyID: {{ .Values.taskqueue.accessKey }}
-  secretAccessKey: {{ .Values.taskqueue.secretKey }}
+  bucket: {{ .Values.lunchpail.taskqueue.bucket }}
+  endpoint: {{ .Values.lunchpail.taskqueue.endpoint }}
+  accessKeyID: {{ .Values.lunchpail.taskqueue.accessKey }}
+  secretAccessKey: {{ .Values.lunchpail.taskqueue.secretKey }}

--- a/pkg/fe/template/chart/templates/image-pull-secret.yaml
+++ b/pkg/fe/template/chart/templates/image-pull-secret.yaml
@@ -1,10 +1,10 @@
-{{- if .Values.global.jaas.dockerconfigjson }}
+{{- if .Values.lunchpail.ips.dockerconfigjson }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.global.jaas.ips }}
+  name: {{ .Values.lunchpail.ips.name }}
   namespace: {{ .Release.Namespace }}
 type: kubernetes.io/dockerconfigjson
 data:
-  .dockerconfigjson: {{ .Values.global.jaas.dockerconfigjson }}
+  .dockerconfigjson: {{ .Values.lunchpail.ips.dockerconfigjson }}
 {{- end }}

--- a/pkg/fe/template/chart/templates/namespace.yaml
+++ b/pkg/fe/template/chart/templates/namespace.yaml
@@ -1,10 +1,10 @@
-{{- if .Values.global.jaas.namespace.create }}
+{{- if .Values.lunchpail.namespace.create }}
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: {{ .Values.global.jaas.namespace.name }}
+  name: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/name: {{ .Values.global.jaas.namespace.name }}
+    app.kubernetes.io/name: {{ .Values.lunchpail.namespace.name }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
     app.kubernetes.io/part-of: jaas
 {{- end }}

--- a/pkg/fe/template/chart/templates/rbac.yaml
+++ b/pkg/fe/template/chart/templates/rbac.yaml
@@ -1,11 +1,11 @@
-{{- if .Values.rbac.serviceaccount }}
+{{- if .Values.lunchpail.rbac.serviceaccount }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.rbac.serviceaccount }}
-  namespace: {{ .Values.namespace.user }}
-{{- if .Values.global.jaas.ips }}
+  name: {{ .Values.lunchpail.rbac.serviceaccount }}
+  namespace: {{ .Release.Namespace }}
+{{- if .Values.lunchpail.ips.name }}
 imagePullSecrets:
-  - name: {{ .Values.global.jaas.ips }}
+  - name: {{ .Values.lunchpail.ips.name }}
 {{- end }}
 {{- end }}

--- a/pkg/fe/template/chart/templates/scc.yaml
+++ b/pkg/fe/template/chart/templates/scc.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.global.type "oc"}}
+{{- if and .Values.global (eq .Values.global.type "oc")}}
 kind: SecurityContextConstraints
 apiVersion: security.openshift.io/v1
 metadata:
@@ -31,5 +31,5 @@ supplementalGroups:
 volumes:
 - '*'
 users:
-- system:serviceaccount:{{ .Values.namespace.user }}:{{ .Values.rbac.serviceaccount }}
+- system:serviceaccount:{{ .Release.Namespace }}:{{ .Values.lunchpail.rbac.serviceaccount }}
 {{- end }}

--- a/pkg/fe/transformer/api/shell/chart/templates/podspec.yaml
+++ b/pkg/fe/transformer/api/shell/chart/templates/podspec.yaml
@@ -13,8 +13,8 @@ spec:
 
   terminationGracePeriodSeconds: {{ .Values.lunchpail.terminationGracePeriodSeconds | default 0 }}
 
-  {{- if .Values.rbac.serviceaccount }}
-  serviceAccountName: {{ .Values.rbac.serviceaccount }}
+  {{- if .Values.lunchpail.rbac.serviceaccount }}
+  serviceAccountName: {{ .Values.lunchpail.rbac.serviceaccount }}
   {{- end }}
 
   {{- include "prestop/spec/pod" . | indent 2 }}

--- a/pkg/fe/transformer/api/shell/lower.go
+++ b/pkg/fe/transformer/api/shell/lower.go
@@ -100,7 +100,7 @@ func LowerAsComponent(compilationName, runname, namespace string, app hlir.Appli
 		"envFroms=" + envFroms,
 		"env=" + env,
 		"taskqueue.prefixPath=" + queuePrefixPath,
-		"rbac.serviceaccount=" + spec.ServiceAccount,
+		"lunchpail.rbac.serviceaccount=" + spec.ServiceAccount,
 		"securityContext=" + securityContext,
 		"containerSecurityContext=" + containerSecurityContext,
 		"workdir.cm.data=" + workdirCmData,

--- a/tests/tests/test0b/pail/app.yaml
+++ b/tests/tests/test0b/pail/app.yaml
@@ -2,7 +2,6 @@ apiVersion: lunchpail.io/v1alpha1
 kind: Application
 metadata:
   name: test0b
-  namespace: {{ .Values.namespace.user }}
 spec:
   image: ubuntu
   repo: https://github.com/does/not/exist/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx # expect failure

--- a/tests/tests/test7-wait-withfail/pail/dataset-secret.yaml
+++ b/tests/tests/test7-wait-withfail/pail/dataset-secret.yaml
@@ -4,6 +4,6 @@ metadata:
   name: test7data
 type: Opaque
 stringData:
-  endpoint: {{ .Values.taskqueue.endpoint }}
-  accessKeyID: {{ .Values.taskqueue.accessKey }}
-  secretAccessKey: {{ .Values.taskqueue.secretKey }}
+  endpoint: {{ .Values.lunchpail.taskqueue.endpoint }}
+  accessKeyID: {{ .Values.lunchpail.taskqueue.accessKey }}
+  secretAccessKey: {{ .Values.lunchpail.taskqueue.secretKey }}

--- a/tests/tests/test7-wait/pail/dataset-secret.yaml
+++ b/tests/tests/test7-wait/pail/dataset-secret.yaml
@@ -4,6 +4,6 @@ metadata:
   name: test7data
 type: Opaque
 stringData:
-  endpoint: {{ .Values.taskqueue.endpoint }}
-  accessKeyID: {{ .Values.taskqueue.accessKey }}
-  secretAccessKey: {{ .Values.taskqueue.secretKey }}
+  endpoint: {{ .Values.lunchpail.taskqueue.endpoint }}
+  accessKeyID: {{ .Values.lunchpail.taskqueue.accessKey }}
+  secretAccessKey: {{ .Values.lunchpail.taskqueue.secretKey }}

--- a/tests/tests/test7/pail/dataset-secret.yaml
+++ b/tests/tests/test7/pail/dataset-secret.yaml
@@ -4,6 +4,6 @@ metadata:
   name: test7data
 type: Opaque
 stringData:
-  endpoint: {{ .Values.taskqueue.endpoint }}
-  accessKeyID: {{ .Values.taskqueue.accessKey }}
-  secretAccessKey: {{ .Values.taskqueue.secretKey }}
+  endpoint: {{ .Values.lunchpail.taskqueue.endpoint }}
+  accessKeyID: {{ .Values.lunchpail.taskqueue.accessKey }}
+  secretAccessKey: {{ .Values.lunchpail.taskqueue.secretKey }}

--- a/tests/tests/test7b/pail/dataset-secret.yaml
+++ b/tests/tests/test7b/pail/dataset-secret.yaml
@@ -4,6 +4,6 @@ metadata:
   name: test7bdata
 type: Opaque
 stringData:
-  endpoint: {{ .Values.taskqueue.endpoint }}
-  accessKeyID: {{ .Values.taskqueue.accessKey }}
-  secretAccessKey: {{ .Values.taskqueue.secretKey }}
+  endpoint: {{ .Values.lunchpail.taskqueue.endpoint }}
+  accessKeyID: {{ .Values.lunchpail.taskqueue.accessKey }}
+  secretAccessKey: {{ .Values.lunchpail.taskqueue.secretKey }}

--- a/tests/tests/test7c/pail/dataset-secret.yaml
+++ b/tests/tests/test7c/pail/dataset-secret.yaml
@@ -7,6 +7,6 @@ metadata:
 type: Opaque
 stringData:
   bucket: {{ "test7c" }}
-  endpoint: {{ .Values.taskqueue.endpoint }}
-  accessKeyID: {{ .Values.taskqueue.accessKey }}
-  secretAccessKey: {{ .Values.taskqueue.secretKey }}
+  endpoint: {{ .Values.lunchpail.taskqueue.endpoint }}
+  accessKeyID: {{ .Values.lunchpail.taskqueue.accessKey }}
+  secretAccessKey: {{ .Values.lunchpail.taskqueue.secretKey }}

--- a/tests/tests/test7e-by-role-autorun/pail/dataset-secret.yaml
+++ b/tests/tests/test7e-by-role-autorun/pail/dataset-secret.yaml
@@ -4,6 +4,6 @@ metadata:
   name: test7edata-cfsecret # avoid dashes for now: https://github.com/datashim-io/datashim/issues/285
 type: Opaque
 stringData:
-  endpoint: {{ .Values.taskqueue.endpoint }}
-  accessKeyID: {{ .Values.taskqueue.accessKey }}
-  secretAccessKey: {{ .Values.taskqueue.secretKey }}
+  endpoint: {{ .Values.lunchpail.taskqueue.endpoint }}
+  accessKeyID: {{ .Values.lunchpail.taskqueue.accessKey }}
+  secretAccessKey: {{ .Values.lunchpail.taskqueue.secretKey }}

--- a/tests/tests/test7e-by-role-autorun/pail/dataset.yaml
+++ b/tests/tests/test7e-by-role-autorun/pail/dataset.yaml
@@ -8,8 +8,8 @@ spec:
   local:
     type: "COS"
     bucket: test7e-by-role-autorun
-    endpoint: {{ .Values.taskqueue.endpoint }}
+    endpoint: {{ .Values.lunchpail.taskqueue.endpoint }}
     secret-name: test7edata-cfsecret
-    secret-namespace: {{ .Values.namespace.user }}
+    secret-namespace: {{ .Release.Namespace }}
     #readonly: "true" # default is false
     provision: "true"

--- a/tests/tests/test7e-by-role/pail/dataset-secret.yaml
+++ b/tests/tests/test7e-by-role/pail/dataset-secret.yaml
@@ -4,5 +4,5 @@ metadata:
   name: test7edata-cfsecret # avoid dashes for now: https://github.com/datashim-io/datashim/issues/285
 type: Opaque
 stringData:
-  accessKeyID: {{ .Values.taskqueue.accessKey }}
-  secretAccessKey: {{ .Values.taskqueue.secretKey }}
+  accessKeyID: {{ .Values.lunchpail.taskqueue.accessKey }}
+  secretAccessKey: {{ .Values.lunchpail.taskqueue.secretKey }}

--- a/tests/tests/test7e-by-role/pail/dataset.yaml
+++ b/tests/tests/test7e-by-role/pail/dataset.yaml
@@ -8,8 +8,8 @@ spec:
   local:
     type: "COS"
     bucket: test7e-by-role
-    endpoint: {{ .Values.taskqueue.endpoint }}
+    endpoint: {{ .Values.lunchpail.taskqueue.endpoint }}
     secret-name: test7edata-cfsecret
-    secret-namespace: {{ .Values.namespace.user }}
+    secret-namespace: {{ .Release.Namespace}}
     #readonly: "true" # default is false
     provision: "true"

--- a/tests/tests/test7e/pail/dataset-secret.yaml
+++ b/tests/tests/test7e/pail/dataset-secret.yaml
@@ -5,6 +5,6 @@ metadata:
   name: test7edata-cfsecret # avoid dashes for now: https://github.com/datashim-io/datashim/issues/285
 type: Opaque
 stringData:
-  accessKeyID: {{ .Values.taskqueue.accessKey }}
-  secretAccessKey: {{ .Values.taskqueue.secretKey }}
+  accessKeyID: {{ .Values.lunchpail.taskqueue.accessKey }}
+  secretAccessKey: {{ .Values.lunchpail.taskqueue.secretKey }}
 {{- end }}

--- a/tests/tests/test7e/pail/dataset.yaml
+++ b/tests/tests/test7e/pail/dataset.yaml
@@ -9,9 +9,9 @@ spec:
   local:
     type: "COS"
     bucket: test7e
-    endpoint: {{ .Values.taskqueue.endpoint }}
+    endpoint: {{ .Values.lunchpail.taskqueue.endpoint }}
     secret-name: test7edata-cfsecret
-    secret-namespace: {{ .Values.namespace.user }}
+    secret-namespace: {{ .Release.Namespace }}
     #readonly: "true" # default is false
     provision: "true"
 {{- end }}

--- a/tests/tests/test7h/pail/dataset-secret.yaml
+++ b/tests/tests/test7h/pail/dataset-secret.yaml
@@ -8,7 +8,7 @@ metadata:
 type: Opaque
 stringData:
   bucket: {{ "test7h" }}
-  endpoint: {{ .Values.taskqueue.endpoint }}
-  accessKeyID: {{ .Values.taskqueue.accessKey }}
-  secretAccessKey: {{ .Values.taskqueue.secretKey }}
+  endpoint: {{ .Values.lunchpail.taskqueue.endpoint }}
+  accessKeyID: {{ .Values.lunchpail.taskqueue.accessKey }}
+  secretAccessKey: {{ .Values.lunchpail.taskqueue.secretKey }}
 {{- end }}


### PR DESCRIPTION
Places more lunchpail (rather than application- or user-provided) values under a lunchpail.xxx subtree

BREAKING CHANGE: Values.user and Values.uid become Values.lunchpail.user.name and Values.lunchpail.user.uid

BREAKING CHANGE: Values.namespace.user becomes .Release.Namespace

BREAKING CHANGE: Values.taskqueue becomes Values.lunchpail.taskqueue