### PR TITLE
feat: pass through yaml values to transformer

### DIFF
--- a/pkg/fe/compile.go
+++ b/pkg/fe/compile.go
@@ -48,7 +48,7 @@ func Compile(backend be.Backend, opts CompileOptions) (ir.Linked, error) {
 		fmt.Fprintf(os.Stderr, "Using internal S3 port %d\n", internalS3Port)
 	}
 
-	yamlValues, dashdashSetValues, dashdashSetFileValues, queueSpec, serviceAccount, err := linker.Configure(compilationName, runname, namespace, templatePath, internalS3Port, backend, opts.ConfigureOptions)
+	yamlValues, dashdashSetValues, dashdashSetFileValues, queueSpec, err := linker.Configure(compilationName, runname, namespace, templatePath, internalS3Port, backend, opts.ConfigureOptions)
 	if err != nil {
 		return ir.Linked{}, err
 	}
@@ -58,7 +58,7 @@ func Compile(backend be.Backend, opts CompileOptions) (ir.Linked, error) {
 		return ir.Linked{}, err
 	} else if hlir, err := parser.Parse(yaml); err != nil {
 		return ir.Linked{}, err
-	} else if llir, err := transformer.Lower(compilationName, runname, namespace, hlir, queueSpec, serviceAccount, opts.ConfigureOptions.CompilationOptions, opts.Verbose); err != nil {
+	} else if llir, err := transformer.Lower(compilationName, runname, namespace, hlir, queueSpec, yamlValues, opts.ConfigureOptions.CompilationOptions, opts.Verbose); err != nil {
 		return ir.Linked{}, err
 	} else {
 		return ir.Linked{

--- a/pkg/fe/linker/configure.go
+++ b/pkg/fe/linker/configure.go
@@ -18,14 +18,14 @@ type ConfigureOptions struct {
 	Verbose            bool
 }
 
-func Configure(appname, runname, namespace, templatePath string, internalS3Port int, backend be.Backend, opts ConfigureOptions) (string, []string, []string, queue.Spec, string, error) {
+func Configure(appname, runname, namespace, templatePath string, internalS3Port int, backend be.Backend, opts ConfigureOptions) (string, []string, []string, queue.Spec, error) {
 	if opts.Verbose {
 		fmt.Fprintf(os.Stderr, "Stage directory %s\n", templatePath)
 	}
 
 	shrinkwrappedOptions, err := compilation.RestoreOptions(templatePath)
 	if err != nil {
-		return "", nil, nil, queue.Spec{}, "", err
+		return "", nil, nil, queue.Spec{}, err
 	} else {
 		if opts.CompilationOptions.Namespace == "" {
 			opts.CompilationOptions.Namespace = shrinkwrappedOptions.Namespace
@@ -57,17 +57,17 @@ func Configure(appname, runname, namespace, templatePath string, internalS3Port 
 
 	queueSpec, err := queue.ParseFlag(opts.CompilationOptions.Queue, runname, internalS3Port)
 	if err != nil {
-		return "", nil, nil, queue.Spec{}, "", err
+		return "", nil, nil, queue.Spec{}, err
 	}
 
 	imagePullSecretName, dockerconfigjson, ipsErr := imagePullSecret(opts.CompilationOptions.ImagePullSecret)
 	if ipsErr != nil {
-		return "", nil, nil, queue.Spec{}, "", ipsErr
+		return "", nil, nil, queue.Spec{}, ipsErr
 	}
 
 	user, err := user.Current()
 	if err != nil {
-		return "", nil, nil, queue.Spec{}, "", err
+		return "", nil, nil, queue.Spec{}, err
 	}
 
 	// the app.kubernetes.io/part-of label value
@@ -86,7 +86,7 @@ func Configure(appname, runname, namespace, templatePath string, internalS3Port 
 
 	backendValues, err := backend.Values()
 	if err != nil {
-		return "", nil, nil, queue.Spec{}, "", err
+		return "", nil, nil, queue.Spec{}, err
 	}
 
 	serviceAccount := runname
@@ -149,5 +149,5 @@ partOf: %s # partOf (16)
 	overrides := slices.Concat(opts.CompilationOptions.OverrideValues, backendValues.Kv)
 	fileOverrides := opts.CompilationOptions.OverrideFileValues // Note: no backend value support here
 
-	return yaml, overrides, fileOverrides, queueSpec, serviceAccount, nil
+	return yaml, overrides, fileOverrides, queueSpec, nil
 }

--- a/pkg/fe/transformer/api/shell/chart/templates/job.yaml
+++ b/pkg/fe/transformer/api/shell/chart/templates/job.yaml
@@ -4,7 +4,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ print .Release.Name | trunc 53 | trimSuffix "-" }}
-  namespace: {{ .Values.namespace }}
   labels:
     app.kubernetes.io/component: {{ .Values.component }}
     app.kubernetes.io/part-of: {{ .Values.partOf }}

--- a/pkg/fe/transformer/api/shell/chart/templates/pod.yaml
+++ b/pkg/fe/transformer/api/shell/chart/templates/pod.yaml
@@ -4,7 +4,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: {{ .Release.Name }}
-  namespace: {{ .Values.namespace }}
   {{- include "pod/labels" . | indent 2 }}
 {{- include "pod/spec" . }}
 {{- end }}

--- a/pkg/fe/transformer/api/shell/chart/templates/service.yaml
+++ b/pkg/fe/transformer/api/shell/chart/templates/service.yaml
@@ -4,7 +4,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}
-  namespace: {{ .Values.namespace }}
   labels:
     app.kubernetes.io/component: {{ .Values.component }}
     app.kubernetes.io/part-of: {{ .Values.partOf }}

--- a/pkg/fe/transformer/api/shell/chart/templates/workdir.yaml
+++ b/pkg/fe/transformer/api/shell/chart/templates/workdir.yaml
@@ -30,7 +30,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ print (.Release.Name | trunc 44) "-workdir" }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: {{ .Values.component }}
     app.kubernetes.io/name: {{ .Values.name }}

--- a/pkg/fe/transformer/api/shell/lower.go
+++ b/pkg/fe/transformer/api/shell/lower.go
@@ -82,13 +82,10 @@ func LowerAsComponent(compilationName, runname, namespace string, app hlir.Appli
 	}
 
 	values := []string{
-		"name=" + runname,
 		"lunchpail.instanceName=" + instanceName,
-		"partOf=" + compilationName,
 		"component=" + string(component),
 		"enclosingRun=" + runname,
 		"image=" + app.Spec.Image,
-		"namespace=" + namespace,
 		"command=" + app.Spec.Command,
 		"workers.count=" + strconv.Itoa(sizing.Workers),
 		"workers.cpu=" + sizing.Cpu,
@@ -100,15 +97,11 @@ func LowerAsComponent(compilationName, runname, namespace string, app hlir.Appli
 		"envFroms=" + envFroms,
 		"env=" + env,
 		"taskqueue.prefixPath=" + queuePrefixPath,
-		"lunchpail.rbac.serviceaccount=" + spec.ServiceAccount,
 		"securityContext=" + securityContext,
 		"containerSecurityContext=" + containerSecurityContext,
 		"workdir.cm.data=" + workdirCmData,
 		"workdir.cm.mount_path=" + workdirCmMountPath,
 		fmt.Sprintf("lunchpail.runAsJob=%v", spec.RunAsJob),
-		"lunchpail.image.registry=" + lunchpail.ImageRegistry,
-		"lunchpail.image.repo=" + lunchpail.ImageRepo,
-		"lunchpail.image.version=" + lunchpail.Version(),
 		"lunchpail.terminationGracePeriodSeconds=" + strconv.Itoa(terminationGracePeriodSeconds),
 	}
 
@@ -120,5 +113,5 @@ func LowerAsComponent(compilationName, runname, namespace string, app hlir.Appli
 		fmt.Fprintf(os.Stderr, "Shell values\n%s\n", strings.Replace(strings.Join(values, "\n  - "), workdirCmData, "", 1))
 	}
 
-	return api.GenerateComponent(instanceName, namespace, templatePath, values, verbose, component)
+	return api.GenerateComponent(instanceName, namespace, templatePath, spec.Values.Yaml, values, verbose, component)
 }

--- a/pkg/fe/transformer/api/template.go
+++ b/pkg/fe/transformer/api/template.go
@@ -21,8 +21,8 @@ const (
 	pods         = "pods"
 )
 
-func extract(which which, name comp.Component, runname, namespace, templatePath string, values []string, verbose bool) (string, error) {
-	parts, err := template.Template(runname+"-"+string(name), namespace, templatePath, "", template.TemplateOptions{Verbose: verbose, OverrideValues: append(values, "extract="+string(which))})
+func extract(which which, name comp.Component, runname, namespace, templatePath string, yamlValues string, dashdashSetValues []string, verbose bool) (string, error) {
+	parts, err := template.Template(runname+"-"+string(name), namespace, templatePath, yamlValues, template.TemplateOptions{Verbose: verbose, OverrideValues: append(dashdashSetValues, "extract="+string(which))})
 	if err != nil {
 		return "", err
 	}
@@ -32,10 +32,10 @@ func extract(which which, name comp.Component, runname, namespace, templatePath 
 
 // reparse marshaled jobs into typed batchv1.Job objects, because this
 // helps backends interpret the LLIR
-func extractJobs(name comp.Component, runname, namespace, templatePath string, values []string, verbose bool) ([]batchv1.Job, error) {
+func extractJobs(name comp.Component, runname, namespace, templatePath string, yamlValues string, dashdashSetValues []string, verbose bool) ([]batchv1.Job, error) {
 	jobs := []batchv1.Job{}
 
-	job, err := extract("job", name, runname, namespace, templatePath, values, verbose)
+	job, err := extract("job", name, runname, namespace, templatePath, yamlValues, dashdashSetValues, verbose)
 	if err != nil {
 		return jobs, err
 	}
@@ -65,10 +65,10 @@ func extractJobs(name comp.Component, runname, namespace, templatePath string, v
 // TODO there has to be some way to share code here with extractJobs
 // reparse marshaled jobs into typed corev1.Pod objects, because this
 // helps backends interpret the LLIR
-func extractPods(name comp.Component, runname, namespace, templatePath string, values []string, verbose bool) ([]corev1.Pod, error) {
+func extractPods(name comp.Component, runname, namespace, templatePath string, yamlValues string, dashdashSetValues []string, verbose bool) ([]corev1.Pod, error) {
 	pods := []corev1.Pod{}
 
-	pod, err := extract("pods", name, runname, namespace, templatePath, values, verbose)
+	pod, err := extract("pods", name, runname, namespace, templatePath, yamlValues, dashdashSetValues, verbose)
 	if err != nil {
 		return pods, err
 	}
@@ -95,18 +95,18 @@ func extractPods(name comp.Component, runname, namespace, templatePath string, v
 	return pods, nil
 }
 
-func GenerateComponent(runname, namespace, templatePath string, values []string, verbose bool, name comp.Component) (llir.Component, error) {
-	config, err := extract("config", name, runname, namespace, templatePath, values, verbose)
+func GenerateComponent(runname, namespace, templatePath string, yamlValues string, dashdashSetValues []string, verbose bool, name comp.Component) (llir.Component, error) {
+	config, err := extract("config", name, runname, namespace, templatePath, yamlValues, dashdashSetValues, verbose)
 	if err != nil {
 		return llir.Component{}, err
 	}
 
-	jobs, err := extractJobs(name, runname, namespace, templatePath, values, verbose)
+	jobs, err := extractJobs(name, runname, namespace, templatePath, yamlValues, dashdashSetValues, verbose)
 	if err != nil {
 		return llir.Component{}, err
 	}
 
-	pods, err := extractPods(name, runname, namespace, templatePath, values, verbose)
+	pods, err := extractPods(name, runname, namespace, templatePath, yamlValues, dashdashSetValues, verbose)
 	if err != nil {
 		return llir.Component{}, err
 	}

--- a/pkg/fe/transformer/lower.go
+++ b/pkg/fe/transformer/lower.go
@@ -13,8 +13,8 @@ import (
 )
 
 // HLIR -> LLIR
-func Lower(compilationName, runname, namespace string, model hlir.AppModel, queueSpec queue.Spec, serviceAccount string, opts compilation.Options, verbose bool) (llir.LLIR, error) {
-	spec := llir.ApplicationInstanceSpec{Queue: queueSpec, ServiceAccount: serviceAccount}
+func Lower(compilationName, runname, namespace string, model hlir.AppModel, queueSpec queue.Spec, yamlValues string, opts compilation.Options, verbose bool) (llir.LLIR, error) {
+	spec := llir.ApplicationInstanceSpec{Queue: queueSpec, Values: llir.Values{Yaml: yamlValues}}
 
 	minio, err := minio.Lower(compilationName, runname, namespace, model, spec, opts, verbose)
 	if err != nil {

--- a/pkg/ir/llir/application_instance.go
+++ b/pkg/ir/llir/application_instance.go
@@ -4,6 +4,10 @@ import (
 	"lunchpail.io/pkg/fe/linker/queue"
 )
 
+type Values struct {
+	Yaml string
+}
+
 type ApplicationInstanceSpec struct {
 	// Use a Job-style (versus Pod-style) of deployment?
 	RunAsJob bool
@@ -17,8 +21,8 @@ type ApplicationInstanceSpec struct {
 	// Where runners of this instance should pick up or dispatch queue data
 	QueuePrefixPath string
 
-	// Kubernetes-specific
-	ServiceAccount string
+	// Template values
+	Values
 
 	// Sizing of this instance
 	Sizing RunSizeConfig

--- a/tests/tests/test7f/pail/worker.yaml
+++ b/tests/tests/test7f/pail/worker.yaml
@@ -23,4 +23,5 @@ spec:
 
   command: ./literal.sh
   env:
+    USER: {{ .Values.lunchpail.user.namey }}
     WORK_TIME: {{ .Values.duration | default 5 | quote }}


### PR DESCRIPTION
this allows us to skip some duplicate values in shell/lower that are also in linker/configure. we can now skip passing through (oddly) service account from configure to lower