### PR TITLE
feat: remove Values.enclosingRun

### DIFF
--- a/pkg/fe/transformer/api/shell/chart/templates/podlabels.yaml
+++ b/pkg/fe/transformer/api/shell/chart/templates/podlabels.yaml
@@ -1,8 +1,12 @@
 {{- define "pod/labels" }}
 labels:
-  app.kubernetes.io/component: {{ .Values.component }}
-  app.kubernetes.io/part-of: {{ .Values.partOf }}
-  app.kubernetes.io/name: {{ .Values.lunchpail.instanceName }}
-  app.kubernetes.io/instance: {{ .Values.name }}
-  app.kubernetes.io/managed-by: lunchpail.io
+  {{- include "labels" . | indent 2 }}
+{{- end }}
+
+{{- define "labels" }}
+app.kubernetes.io/component: {{ $.Values.component }}
+app.kubernetes.io/part-of: {{ $.Values.partOf }}
+app.kubernetes.io/name: {{ $.Values.lunchpail.instanceName }}
+app.kubernetes.io/instance: {{ $.Values.name }}
+app.kubernetes.io/managed-by: lunchpail.io
 {{- end }}

--- a/pkg/fe/transformer/api/shell/chart/templates/service.yaml
+++ b/pkg/fe/transformer/api/shell/chart/templates/service.yaml
@@ -4,12 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}
-  labels:
-    app.kubernetes.io/component: {{ .Values.component }}
-    app.kubernetes.io/part-of: {{ .Values.partOf }}
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/instance: {{ .Values.enclosingRun }}
-    app.kubernetes.io/managed-by: lunchpail.io
+  {{- include "pod/labels" . | indent 2 }}
 spec:
   ports:
   {{- range $port := .Values.expose }}
@@ -19,10 +14,7 @@ spec:
     targetPort: {{ index $parts 1 }}
     protocol: TCP
   selector:
-    app.kubernetes.io/component: {{ $.Values.component }}
-    app.kubernetes.io/part-of: {{ $.Values.partOf }}
-    app.kubernetes.io/name: {{ $.Values.name }}
-    app.kubernetes.io/instance: {{ $.Values.enclosingRun }}
+    {{- include "labels" $ | indent 4 }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/pkg/fe/transformer/api/shell/lower.go
+++ b/pkg/fe/transformer/api/shell/lower.go
@@ -84,7 +84,6 @@ func LowerAsComponent(compilationName, runname, namespace string, app hlir.Appli
 	values := []string{
 		"lunchpail.instanceName=" + instanceName,
 		"component=" + string(component),
-		"enclosingRun=" + runname,
 		"image=" + app.Spec.Image,
 		"command=" + app.Spec.Command,
 		"workers.count=" + strconv.Itoa(sizing.Workers),


### PR DESCRIPTION
BREAKING CHANGE: this may break ancient charts

This also consolidates some of the pod and service labeling in charts/shell