### PR TITLE
fix: trim more from the image builds

### DIFF
--- a/cmd/subcommands/info.go
+++ b/cmd/subcommands/info.go
@@ -1,3 +1,5 @@
+//go:build full || manage || observe
+
 package subcommands
 
 import (

--- a/pkg/be/runs/pretty.go
+++ b/pkg/be/runs/pretty.go
@@ -5,17 +5,15 @@ import (
 	"strings"
 	"time"
 
-	"github.com/charmbracelet/lipgloss"
 	"github.com/dustin/go-humanize"
 )
 
 func Pretty(runs []Run) string {
 	names := []string{}
 	now := time.Now()
-	dim := lipgloss.NewStyle().Faint(true)
 
 	for _, run := range runs {
-		names = append(names, fmt.Sprintf("%s %s", run.Name, dim.Render(humanize.RelTime(run.CreationTimestamp, now, "ago", "from now"))))
+		names = append(names, fmt.Sprintf("%s %s", run.Name, humanize.RelTime(run.CreationTimestamp, now, "ago", "from now")))
 	}
 
 	return strings.Join(names, "\n")


### PR DESCRIPTION
- eliminates the superfluous use of charmbracelet from pkg/be
- adds go:build tag to info command

19.2Mi -> 18.1Mi for the image
9.8Mi -> 8.8Mi for the binary build (in the image)

Overall, down from 60Mi for the binary build (in the image)