### PR TITLE
fix: stabilize tests

### DIFF
--- a/pkg/be/kubernetes/shell/template.go
+++ b/pkg/be/kubernetes/shell/template.go
@@ -56,7 +56,7 @@ func Template(ir llir.LLIR, c llir.ShellComponent, namespace string, opts common
 		"image=" + c.Application.Spec.Image,
 		"command=" + c.Application.Spec.Command,
 		fmt.Sprintf("lunchpail.runAsJob=%v", c.RunAsJob),
-		fmt.Sprintf("lunchpail.debug=%v", verbose),
+		// fmt.Sprintf("lunchpail.debug=%v", verbose),
 		"lunchpail.terminationGracePeriodSeconds=" + strconv.Itoa(terminationGracePeriodSeconds),
 		"workers.count=" + strconv.Itoa(c.Sizing.Workers),
 		"workers.cpu=" + c.Sizing.Cpu,

--- a/pkg/fe/transformer/api/minio/transpile.go
+++ b/pkg/fe/transformer/api/minio/transpile.go
@@ -2,7 +2,6 @@ package minio
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -35,10 +34,8 @@ func transpile(runname string, ir llir.LLIR) (hlir.Application, error) {
 	app.Spec.Env["LUNCHPAIL_QUEUE_BUCKET"] = ir.Queue.Bucket
 	app.Spec.Env["LUNCHPAIL_QUEUE_PREFIX"] = prefixExcludingBucket
 
-	if os.Getenv("CI") != "" {
-		// Helps with tests. see ./minio.sh
-		app.Spec.Env["LUNCHPAIL_SLEEP_BEFORE_EXIT"] = "5"
-	}
+	// Helps with tests. see ./minio.sh
+	app.Spec.Env["LUNCHPAIL_SLEEP_BEFORE_EXIT"] = "5"
 
 	return app, nil
 }

--- a/pkg/runtime/queue/copyin.go
+++ b/pkg/runtime/queue/copyin.go
@@ -15,11 +15,12 @@ func CopyIn(srcDir, bucket string) error {
 		return err
 	}
 
-	fmt.Fprintf(os.Stderr, "Uploading files from local directory=%s to s3 bucket=%s\n", srcDir, bucket)
+	fmt.Fprintf(os.Stderr, "Preparing upload with mkdirp on s3 bucket=%s\n", bucket)
 	if err := s3.Mkdirp(bucket); err != nil {
 		return err
 	}
 
+	fmt.Fprintf(os.Stderr, "Uploading files from local directory=%s to s3 bucket=%s\n", srcDir, bucket)
 	if err := filepath.WalkDir(srcDir, func(path string, dir fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/runtime/workstealer/run.go
+++ b/pkg/runtime/workstealer/run.go
@@ -69,6 +69,10 @@ func Run() error {
 	fmt.Printf("INFO Workstealer starting")
 	printenv()
 
+	if err := c.s3.Mkdirp(s3.Paths.Bucket); err != nil {
+		return err
+	}
+
 	for {
 		// fetch model
 		m := c.fetchModel()

--- a/tests/bin/add-data.sh
+++ b/tests/bin/add-data.sh
@@ -27,8 +27,8 @@ for bucket_path in $@; do
         done
         
         set -x
-        kubectl cp $bucket_path $pod:/tmp/$bucket -n $NAMESPACE
-        kubectl exec $pod -n $NAMESPACE -- sh -c "lunchpail qin /tmp/$bucket $bucket && rm -rf /tmp/$bucket"
+        kubectl cp -c main $bucket_path $pod:/tmp/$bucket -n $NAMESPACE
+        kubectl exec $pod -n $NAMESPACE -c main -- sh -c "lunchpail qin /tmp/$bucket $bucket && rm -rf /tmp/$bucket"
         set +x
     fi
 done


### PR DESCRIPTION
- the tests run in verbose mode, which results in a huge volume of output from the minio server, causing test failures. for now, back this out.
- copy-in rclone needs more retries
- for local testing, minio should also sleep before exit
- (minor) add-data.sh helper script now specifies -c main to avoid spurious console output
- workstealer may fail due to bucket not (yet) existing