### PR TITLE
refactor: rename backend.DeleteNamespace() to backend.Purge()

### DIFF
--- a/pkg/be/backend.go
+++ b/pkg/be/backend.go
@@ -17,8 +17,8 @@ type Backend interface {
 	// Bring down the linked application
 	Down(linked ir.Linked, opts options.CliOptions, verbose bool) error
 
-	// Delete namespace
-	DeleteNamespace(compilationName string) error
+	// Purge any non-run resources that may have been created
+	Purge() error
 
 	// List deployed runs
 	ListRuns(appName string) ([]runs.Run, error)

--- a/pkg/be/ibmcloud/down.go
+++ b/pkg/be/ibmcloud/down.go
@@ -15,7 +15,7 @@ func (backend Backend) Down(linked ir.Linked, opts options.CliOptions, verbose b
 	return nil
 }
 
-func (backend Backend) DeleteNamespace(compilationName string) error {
-	// TODO?
+func (backend Backend) Purge() error {
+	// Is there anything to do here?
 	return nil
 }

--- a/pkg/be/ibmcloud/null.go
+++ b/pkg/be/ibmcloud/null.go
@@ -34,8 +34,7 @@ func (backend Backend) Down(linked ir.Linked, opts options.CliOptions, verbose b
 	return nil
 }
 
-func (backend Backend) DeleteNamespace(compilationName string) error {
-	// TODO?
+func (backend Backend) Purge() error {
 	return nil
 }
 

--- a/pkg/be/kubernetes/namespace.go
+++ b/pkg/be/kubernetes/namespace.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"lunchpail.io/pkg/be/runs"
+	"lunchpail.io/pkg/compilation"
 )
 
 func deleteNamespace(namespace string) error {
@@ -24,8 +26,8 @@ func deleteNamespace(namespace string) error {
 	return nil
 }
 
-func (backend Backend) DeleteNamespace(compilationName string) error {
-	remainingRuns, err := backend.ListRuns(compilationName)
+func (backend Backend) Purge() error {
+	remainingRuns, err := backend.ListRuns(compilation.Name())
 	if err != nil {
 		return err
 	} else if len(remainingRuns) != 0 {

--- a/pkg/be/kubernetes/streamer-null.go
+++ b/pkg/be/kubernetes/streamer-null.go
@@ -60,7 +60,7 @@ func (backend Backend) ChangeWorkers(poolName, poolNamespace, poolContext string
 	return nil
 }
 
-func (backend Backend) DeleteNamespace(compilationName string) error {
+func (backend Backend) Purge() error {
 	return nil
 }
 

--- a/pkg/boot/down.go
+++ b/pkg/boot/down.go
@@ -57,7 +57,7 @@ func DownList(runnames []string, backend be.Backend, opts DownOptions) error {
 	}
 
 	if deleteNs {
-		if err := backend.DeleteNamespace(compilation.Name()); err != nil {
+		if err := backend.Purge(); err != nil {
 			return err
 		}
 	}
@@ -95,20 +95,12 @@ func Down(runname string, backend be.Backend, opts DownOptions) error {
 	}
 
 	upOptions := toUpOpts(runname, opts)
-
-	/* var action ibmcloud.Action
-	if opts.DeleteCloudResources {
-		action = ibmcloud.Delete
-	} else {
-		action = ibmcloud.Stop
-	} */
-
 	if err := upDown(backend, upOptions, false); err != nil {
 		return err
 	}
 
 	if opts.DeleteNamespace {
-		if err := backend.DeleteNamespace(compilation.Name()); err != nil {
+		if err := backend.Purge(); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Also, this function does not need to accept a compilationName, as the impl can get it directly from the compilation API.