### PR TITLE
feat: introduce backend.DryRun

### DIFF
--- a/pkg/be/backend.go
+++ b/pkg/be/backend.go
@@ -5,6 +5,7 @@ import (
 	"lunchpail.io/pkg/be/runs"
 	"lunchpail.io/pkg/be/streamer"
 	"lunchpail.io/pkg/ir"
+	"lunchpail.io/pkg/ir/llir"
 )
 
 type Backend interface {
@@ -16,6 +17,9 @@ type Backend interface {
 
 	// Bring down the linked application
 	Down(linked ir.Linked, opts options.CliOptions, verbose bool) error
+
+	// Return a string to convey relevant dry-run info
+	DryRun(ir llir.LLIR, cliOpts options.CliOptions, verbose bool) (string, error)
 
 	// Purge any non-run resources that may have been created
 	Purge() error

--- a/pkg/be/ibmcloud/api.go
+++ b/pkg/be/ibmcloud/api.go
@@ -5,6 +5,7 @@ package ibmcloud
 import "github.com/IBM/vpc-go-sdk/vpcv1"
 
 type Backend struct {
+	namespace    string
 	config       ibmConfig
 	vpcService   *vpcv1.VpcV1
 	sshKeyType   string

--- a/pkg/be/ibmcloud/create.go
+++ b/pkg/be/ibmcloud/create.go
@@ -377,7 +377,7 @@ func createAndInitVM(vpcService *vpcv1.VpcV1, name string, ir llir.LLIR, resourc
 	return nil
 }
 
-func (backend Backend) SetAction(aopts compilation.Options, ir llir.LLIR, runname, namespace string, action Action, cliOpts options.CliOptions, verbose bool) error {
+func (backend Backend) SetAction(aopts compilation.Options, ir llir.LLIR, runname string, action Action, cliOpts options.CliOptions, verbose bool) error {
 	if action == Stop || action == Delete {
 		if err := stopOrDeleteVM(backend.vpcService, runname, backend.config.ResourceGroup.GUID, action == Delete); err != nil {
 			return err
@@ -391,7 +391,7 @@ func (backend Backend) SetAction(aopts compilation.Options, ir llir.LLIR, runnam
 			}
 			zone = randomZone
 		}
-		if err := createAndInitVM(backend.vpcService, runname, ir, backend.config.ResourceGroup.GUID, backend.sshKeyType, backend.sshPublicKey, zone, aopts.Profile, aopts.ImageID, namespace, cliOpts, verbose); err != nil {
+		if err := createAndInitVM(backend.vpcService, runname, ir, backend.config.ResourceGroup.GUID, backend.sshKeyType, backend.sshPublicKey, zone, aopts.Profile, aopts.ImageID, backend.namespace, cliOpts, verbose); err != nil {
 			return err
 		}
 	}

--- a/pkg/be/ibmcloud/down.go
+++ b/pkg/be/ibmcloud/down.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (backend Backend) Down(linked ir.Linked, opts options.CliOptions, verbose bool) error {
-	if err := backend.SetAction(linked.Options, linked.Ir, linked.Runname, linked.Namespace, Delete, opts, verbose); err != nil {
+	if err := backend.SetAction(linked.Options, linked.Ir, linked.Runname, Delete, opts, verbose); err != nil {
 		return err
 	}
 

--- a/pkg/be/ibmcloud/dryrun.go
+++ b/pkg/be/ibmcloud/dryrun.go
@@ -1,0 +1,14 @@
+//go:build full || manage
+
+package ibmcloud
+
+import (
+	"fmt"
+
+	"lunchpail.io/pkg/be/options"
+	"lunchpail.io/pkg/ir/llir"
+)
+
+func (backend Backend) DryRun(ir llir.LLIR, cliOpts options.CliOptions, verbose bool) (string, error) {
+	return "", fmt.Errorf("Unsupported operation: 'DryRun'")
+}

--- a/pkg/be/ibmcloud/new-options.go
+++ b/pkg/be/ibmcloud/new-options.go
@@ -1,0 +1,8 @@
+package ibmcloud
+
+import "lunchpail.io/pkg/compilation"
+
+type NewOptions struct {
+	Options   compilation.Options
+	Namespace string
+}

--- a/pkg/be/ibmcloud/new.go
+++ b/pkg/be/ibmcloud/new.go
@@ -2,18 +2,14 @@
 
 package ibmcloud
 
-import (
-	"lunchpail.io/pkg/compilation"
-)
+func New(opts NewOptions) (Backend, error) {
+	config := loadConfigWithCommandLineOverrides(opts.Options)
+	keytype, key, err := loadPublicKey(config, opts.Options)
 
-func New(aopts compilation.Options) (Backend, error) {
-	config := loadConfigWithCommandLineOverrides(aopts)
-	keytype, key, err := loadPublicKey(config, aopts)
-
-	vpcService, err := Authenticator(aopts.ApiKey, config)
+	vpcService, err := Authenticator(opts.Options.ApiKey, config)
 	if err != nil {
 		return Backend{}, err
 	}
 
-	return Backend{config, vpcService, keytype, key}, nil
+	return Backend{opts.Namespace, config, vpcService, keytype, key}, nil
 }

--- a/pkg/be/ibmcloud/null.go
+++ b/pkg/be/ibmcloud/null.go
@@ -10,15 +10,15 @@ import (
 	"lunchpail.io/pkg/be/events/utilization"
 	"lunchpail.io/pkg/be/options"
 	"lunchpail.io/pkg/be/streamer"
-	"lunchpail.io/pkg/compilation"
 	"lunchpail.io/pkg/ir"
+	"lunchpail.io/pkg/ir/llir"
 	"lunchpail.io/pkg/lunchpail"
 )
 
 type Backend struct {
 }
 
-func New(aopts compilation.Options) (Backend, error) {
+func New(opts NewOptions) (Backend, error) {
 	return Backend{}, nil
 }
 
@@ -32,6 +32,10 @@ func (backend Backend) Up(linked ir.Linked, opts options.CliOptions, verbose boo
 
 func (backend Backend) Down(linked ir.Linked, opts options.CliOptions, verbose bool) error {
 	return nil
+}
+
+func (backend Backend) DryRun(ir llir.LLIR, cliOpts options.CliOptions, verbose bool) (string, error) {
+	return "", nil
 }
 
 func (backend Backend) Purge() error {

--- a/pkg/be/ibmcloud/up.go
+++ b/pkg/be/ibmcloud/up.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (backend Backend) Up(linked ir.Linked, opts options.CliOptions, verbose bool) error {
-	if err := backend.SetAction(linked.Options, linked.Ir, linked.Runname, linked.Namespace, Create, opts, verbose); err != nil {
+	if err := backend.SetAction(linked.Options, linked.Ir, linked.Runname, Create, opts, verbose); err != nil {
 		return err
 	}
 

--- a/pkg/be/kubernetes/down.go
+++ b/pkg/be/kubernetes/down.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (backend Backend) Down(linked ir.Linked, opts options.CliOptions, verbose bool) error {
-	if err := applyOperation(linked.Ir, linked.Namespace, "", DeleteIt, opts, verbose); err != nil {
+	if err := applyOperation(linked.Ir, backend.Namespace, "", DeleteIt, opts, verbose); err != nil {
 		return err
 	}
 

--- a/pkg/be/kubernetes/marshal.go
+++ b/pkg/be/kubernetes/marshal.go
@@ -44,9 +44,9 @@ func MarshalAllComponents(ir llir.LLIR, namespace string, opts common.Options, v
 
 // This is to present a single string form of all of the yaml,
 // e.g. for dry-running.
-func DryRun(ir llir.LLIR, namespace string, cliOpts options.CliOptions, verbose bool) (string, error) {
+func (backend Backend) DryRun(ir llir.LLIR, cliOpts options.CliOptions, verbose bool) (string, error) {
 	opts := common.Options{CliOptions: cliOpts}
-	if arr, err := MarshalAllComponents(ir, namespace, opts, verbose); err != nil {
+	if arr, err := MarshalAllComponents(ir, backend.Namespace, opts, verbose); err != nil {
 		return "", err
 	} else {
 		return util.Join(arr), nil

--- a/pkg/be/kubernetes/streamer-null.go
+++ b/pkg/be/kubernetes/streamer-null.go
@@ -12,6 +12,7 @@ import (
 	"lunchpail.io/pkg/be/runs"
 	"lunchpail.io/pkg/be/streamer"
 	"lunchpail.io/pkg/ir"
+	"lunchpail.io/pkg/ir/llir"
 	"lunchpail.io/pkg/lunchpail"
 )
 
@@ -50,6 +51,10 @@ func (backend Backend) Up(linked ir.Linked, opts options.CliOptions, verbose boo
 
 func (backend Backend) Down(linked ir.Linked, opts options.CliOptions, verbose bool) error {
 	return nil
+}
+
+func (backend Backend) DryRun(ir llir.LLIR, cliOpts options.CliOptions, verbose bool) (string, error) {
+	return "", nil
 }
 
 func (backend Backend) ListRuns(appName string) ([]runs.Run, error) {

--- a/pkg/be/kubernetes/up.go
+++ b/pkg/be/kubernetes/up.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (backend Backend) Up(linked ir.Linked, opts options.CliOptions, verbose bool) error {
-	if err := applyOperation(linked.Ir, linked.Namespace, "", ApplyIt, opts, verbose); err != nil {
+	if err := applyOperation(linked.Ir, backend.Namespace, "", ApplyIt, opts, verbose); err != nil {
 		return err
 	}
 

--- a/pkg/be/new.go
+++ b/pkg/be/new.go
@@ -20,7 +20,7 @@ func New(topts TargetOptions, aopts compilation.Options) (Backend, error) {
 	case Kubernetes:
 		be = kubernetes.Backend{Namespace: topts.Namespace}
 	case IBMCloud:
-		if ibm, err := ibmcloud.New(aopts); err != nil {
+		if ibm, err := ibmcloud.New(ibmcloud.NewOptions{Options: aopts, Namespace: topts.Namespace}); err != nil {
 			return nil, err
 		} else {
 			be = ibm

--- a/pkg/boot/up.go
+++ b/pkg/boot/up.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"lunchpail.io/pkg/be"
-	"lunchpail.io/pkg/be/kubernetes"
 	"lunchpail.io/pkg/be/options"
 	"lunchpail.io/pkg/fe"
 	"lunchpail.io/pkg/observe/status"
@@ -26,7 +25,7 @@ func upDown(backend be.Backend, opts UpOptions, isUp bool) error {
 	}
 
 	if opts.DryRun {
-		fmt.Printf(kubernetes.DryRun(linked.Ir, linked.Namespace, cliOptions, opts.Verbose))
+		fmt.Printf(backend.DryRun(linked.Ir, cliOptions, opts.Verbose))
 		return nil
 	} else if isUp {
 		if err := backend.Up(linked, cliOptions, opts.Verbose); err != nil {

--- a/pkg/fe/prepare-run.go
+++ b/pkg/fe/prepare-run.go
@@ -106,10 +106,9 @@ func PrepareForRun(opts CompileOptions) (ir.Linked, error) {
 		return ir.Linked{}, err
 	} else {
 		return ir.Linked{
-			Runname:   runname,
-			Namespace: namespace,
-			Ir:        llir,
-			Options:   opts.ConfigureOptions.CompilationOptions,
+			Runname: runname,
+			Ir:      llir,
+			Options: opts.ConfigureOptions.CompilationOptions,
 		}, nil
 	}
 }

--- a/pkg/ir/linked.go
+++ b/pkg/ir/linked.go
@@ -6,8 +6,7 @@ import (
 )
 
 type Linked struct {
-	Runname   string
-	Namespace string
-	Ir        llir.LLIR
-	Options   compilation.Options
+	Runname string
+	Ir      llir.LLIR
+	Options compilation.Options
 }


### PR DESCRIPTION
so that boot/up does not need to hard-coded kubernetes this also helps us eliminate a few more lingering uses of Namespace outside of the backend impls