### PR TITLE
fix: remove superfluous Runname from Linked struct

### DIFF
--- a/pkg/be/ibmcloud/create.go
+++ b/pkg/be/ibmcloud/create.go
@@ -375,7 +375,9 @@ func createAndInitVM(vpcService *vpcv1.VpcV1, name string, ir llir.LLIR, resourc
 	return nil
 }
 
-func (backend Backend) SetAction(aopts compilation.Options, ir llir.LLIR, runname string, action Action, cliOpts options.CliOptions, verbose bool) error {
+func (backend Backend) SetAction(aopts compilation.Options, ir llir.LLIR, action Action, cliOpts options.CliOptions, verbose bool) error {
+	runname := ir.RunName
+
 	if action == Stop || action == Delete {
 		if err := stopOrDeleteVM(backend.vpcService, runname, backend.config.ResourceGroup.GUID, action == Delete); err != nil {
 			return err

--- a/pkg/be/ibmcloud/down.go
+++ b/pkg/be/ibmcloud/down.go
@@ -6,7 +6,7 @@ import (
 )
 
 func (backend Backend) Down(linked ir.Linked, opts options.CliOptions, verbose bool) error {
-	if err := backend.SetAction(linked.Options, linked.Ir, linked.Runname, Delete, opts, verbose); err != nil {
+	if err := backend.SetAction(linked.Options, linked.Ir, Delete, opts, verbose); err != nil {
 		return err
 	}
 

--- a/pkg/be/ibmcloud/up.go
+++ b/pkg/be/ibmcloud/up.go
@@ -6,7 +6,7 @@ import (
 )
 
 func (backend Backend) Up(linked ir.Linked, opts options.CliOptions, verbose bool) error {
-	if err := backend.SetAction(linked.Options, linked.Ir, linked.Runname, Create, opts, verbose); err != nil {
+	if err := backend.SetAction(linked.Options, linked.Ir, Create, opts, verbose); err != nil {
 		return err
 	}
 

--- a/pkg/boot/up.go
+++ b/pkg/boot/up.go
@@ -31,7 +31,7 @@ func upDown(backend be.Backend, opts UpOptions, isUp bool) error {
 		if err := backend.Up(linked, cliOptions, opts.Verbose); err != nil {
 			return err
 		} else if opts.Watch {
-			return status.UI(linked.Runname, backend, status.Options{Watch: true, Verbose: opts.Verbose, Summary: false, Nloglines: 500, IntervalSeconds: 5})
+			return status.UI(linked.Ir.RunName, backend, status.Options{Watch: true, Verbose: opts.Verbose, Summary: false, Nloglines: 500, IntervalSeconds: 5})
 		}
 	} else if err := backend.Down(linked, cliOptions, opts.Verbose); err != nil {
 		return err

--- a/pkg/fe/prepare-run.go
+++ b/pkg/fe/prepare-run.go
@@ -106,7 +106,6 @@ func PrepareForRun(opts CompileOptions) (ir.Linked, error) {
 		return ir.Linked{}, err
 	} else {
 		return ir.Linked{
-			Runname: runname,
 			Ir:      llir,
 			Options: opts.ConfigureOptions.CompilationOptions,
 		}, nil

--- a/pkg/ir/linked.go
+++ b/pkg/ir/linked.go
@@ -6,7 +6,6 @@ import (
 )
 
 type Linked struct {
-	Runname string
 	Ir      llir.LLIR
 	Options compilation.Options
 }


### PR DESCRIPTION
it is in the llir already