### PR TITLE
fix: further simplify options in backend by having llir.Options

### DIFF
--- a/pkg/be/backend.go
+++ b/pkg/be/backend.go
@@ -3,7 +3,6 @@ package be
 import (
 	"lunchpail.io/pkg/be/runs"
 	"lunchpail.io/pkg/be/streamer"
-	"lunchpail.io/pkg/compilation"
 	"lunchpail.io/pkg/ir/llir"
 )
 
@@ -12,13 +11,13 @@ type Backend interface {
 	Ok() error
 
 	// Bring up the linked application
-	Up(linked llir.LLIR, opts compilation.Options, verbose bool) error
+	Up(linked llir.LLIR, opts llir.Options, verbose bool) error
 
 	// Bring down the linked application
-	Down(linked llir.LLIR, opts compilation.Options, verbose bool) error
+	Down(linked llir.LLIR, opts llir.Options, verbose bool) error
 
 	// Return a string to convey relevant dry-run info
-	DryRun(ir llir.LLIR, opts compilation.Options, verbose bool) (string, error)
+	DryRun(ir llir.LLIR, opts llir.Options, verbose bool) (string, error)
 
 	// Purge any non-run resources that may have been created
 	Purge() error

--- a/pkg/be/ibmcloud/create.go
+++ b/pkg/be/ibmcloud/create.go
@@ -19,7 +19,6 @@ import (
 
 	"lunchpail.io/pkg/be/kubernetes"
 	"lunchpail.io/pkg/be/kubernetes/common"
-	"lunchpail.io/pkg/compilation"
 	"lunchpail.io/pkg/ir/llir"
 	"lunchpail.io/pkg/lunchpail"
 	"lunchpail.io/pkg/util"
@@ -39,7 +38,7 @@ const (
 	IPv6Maxlen = 39
 )
 
-func createInstance(vpcService *vpcv1.VpcV1, name string, ir llir.LLIR, c llir.Component, resourceGroupID string, vpcID string, keyID string, zone string, profile string, subnetID string, secGroupID string, imageID string, namespace string, copts compilation.Options, verbose bool) (*vpcv1.Instance, error) {
+func createInstance(vpcService *vpcv1.VpcV1, name string, ir llir.LLIR, c llir.Component, resourceGroupID string, vpcID string, keyID string, zone string, profile string, subnetID string, secGroupID string, imageID string, namespace string, copts llir.Options, verbose bool) (*vpcv1.Instance, error) {
 	networkInterfacePrototypeModel := &vpcv1.NetworkInterfacePrototype{
 		Name: &name,
 		Subnet: &vpcv1.SubnetIdentityByID{
@@ -258,7 +257,7 @@ func createVPC(vpcService *vpcv1.VpcV1, name string, resourceGroupID string) (st
 	return *vpc.ID, nil
 }
 
-func createAndInitVM(vpcService *vpcv1.VpcV1, name string, ir llir.LLIR, resourceGroupID string, keyType string, publicKey string, zone string, profile string, imageID string, namespace string, opts compilation.Options, verbose bool) error {
+func createAndInitVM(vpcService *vpcv1.VpcV1, name string, ir llir.LLIR, resourceGroupID string, keyType string, publicKey string, zone string, profile string, imageID string, namespace string, opts llir.Options, verbose bool) error {
 	t1s := time.Now()
 	vpcID, err := createVPC(vpcService, name, resourceGroupID)
 	if err != nil {
@@ -374,7 +373,7 @@ func createAndInitVM(vpcService *vpcv1.VpcV1, name string, ir llir.LLIR, resourc
 	return nil
 }
 
-func (backend Backend) SetAction(opts compilation.Options, ir llir.LLIR, action Action, verbose bool) error {
+func (backend Backend) SetAction(opts llir.Options, ir llir.LLIR, action Action, verbose bool) error {
 	runname := ir.RunName
 
 	if action == Stop || action == Delete {

--- a/pkg/be/ibmcloud/down.go
+++ b/pkg/be/ibmcloud/down.go
@@ -1,12 +1,9 @@
 package ibmcloud
 
-import (
-	"lunchpail.io/pkg/compilation"
-	"lunchpail.io/pkg/ir/llir"
-)
+import "lunchpail.io/pkg/ir/llir"
 
-func (backend Backend) Down(ir llir.LLIR, copts compilation.Options, verbose bool) error {
-	if err := backend.SetAction(copts, ir, Delete, verbose); err != nil {
+func (backend Backend) Down(ir llir.LLIR, opts llir.Options, verbose bool) error {
+	if err := backend.SetAction(opts, ir, Delete, verbose); err != nil {
 		return err
 	}
 

--- a/pkg/be/ibmcloud/dryrun.go
+++ b/pkg/be/ibmcloud/dryrun.go
@@ -3,10 +3,9 @@ package ibmcloud
 import (
 	"fmt"
 
-	"lunchpail.io/pkg/compilation"
 	"lunchpail.io/pkg/ir/llir"
 )
 
-func (backend Backend) DryRun(ir llir.LLIR, opts compilation.Options, verbose bool) (string, error) {
+func (backend Backend) DryRun(ir llir.LLIR, opts llir.Options, verbose bool) (string, error) {
 	return "", fmt.Errorf("Unsupported operation: 'DryRun'")
 }

--- a/pkg/be/ibmcloud/up.go
+++ b/pkg/be/ibmcloud/up.go
@@ -1,12 +1,9 @@
 package ibmcloud
 
-import (
-	"lunchpail.io/pkg/compilation"
-	"lunchpail.io/pkg/ir/llir"
-)
+import "lunchpail.io/pkg/ir/llir"
 
-func (backend Backend) Up(ir llir.LLIR, copts compilation.Options, verbose bool) error {
-	if err := backend.SetAction(copts, ir, Create, verbose); err != nil {
+func (backend Backend) Up(ir llir.LLIR, opts llir.Options, verbose bool) error {
+	if err := backend.SetAction(opts, ir, Create, verbose); err != nil {
 		return err
 	}
 

--- a/pkg/be/kubernetes/apply.go
+++ b/pkg/be/kubernetes/apply.go
@@ -6,7 +6,6 @@ import (
 	"os/exec"
 	"strings"
 
-	"lunchpail.io/pkg/compilation"
 	"lunchpail.io/pkg/ir/llir"
 	util "lunchpail.io/pkg/util/yaml"
 )
@@ -62,7 +61,7 @@ func apply(yaml, namespace, context string, operation Operation) error {
 	return cmd.Run()
 }
 
-func applyOperation(ir llir.LLIR, namespace, context string, operation Operation, copts compilation.Options, verbose bool) error {
+func applyOperation(ir llir.LLIR, namespace, context string, operation Operation, copts llir.Options, verbose bool) error {
 	opts, err := k8sOptions(copts)
 	if err != nil {
 		return err

--- a/pkg/be/kubernetes/common/options.go
+++ b/pkg/be/kubernetes/common/options.go
@@ -1,9 +1,9 @@
 package common
 
-import "lunchpail.io/pkg/compilation"
+import "lunchpail.io/pkg/ir/llir"
 
 type Options struct {
-	compilation.Options
+	llir.Options
 	NeedsServiceAccount            bool
 	NeedsSecurityContextConstraint bool
 }

--- a/pkg/be/kubernetes/down.go
+++ b/pkg/be/kubernetes/down.go
@@ -1,11 +1,8 @@
 package kubernetes
 
-import (
-	"lunchpail.io/pkg/compilation"
-	"lunchpail.io/pkg/ir/llir"
-)
+import "lunchpail.io/pkg/ir/llir"
 
-func (backend Backend) Down(ir llir.LLIR, opts compilation.Options, verbose bool) error {
+func (backend Backend) Down(ir llir.LLIR, opts llir.Options, verbose bool) error {
 	if err := applyOperation(ir, backend.namespace, "", DeleteIt, opts, verbose); err != nil {
 		return err
 	}

--- a/pkg/be/kubernetes/marshal.go
+++ b/pkg/be/kubernetes/marshal.go
@@ -5,7 +5,6 @@ import (
 
 	"lunchpail.io/pkg/be/kubernetes/common"
 	"lunchpail.io/pkg/be/kubernetes/shell"
-	"lunchpail.io/pkg/compilation"
 	"lunchpail.io/pkg/ir/llir"
 	util "lunchpail.io/pkg/util/yaml"
 )
@@ -42,7 +41,7 @@ func MarshalAllComponents(ir llir.LLIR, namespace string, opts common.Options, v
 
 // This is to present a single string form of all of the yaml,
 // e.g. for dry-running.
-func (backend Backend) DryRun(ir llir.LLIR, copts compilation.Options, verbose bool) (string, error) {
+func (backend Backend) DryRun(ir llir.LLIR, copts llir.Options, verbose bool) (string, error) {
 	opts := common.Options{Options: copts}
 	if arr, err := MarshalAllComponents(ir, backend.namespace, opts, verbose); err != nil {
 		return "", err

--- a/pkg/be/kubernetes/up.go
+++ b/pkg/be/kubernetes/up.go
@@ -1,11 +1,8 @@
 package kubernetes
 
-import (
-	"lunchpail.io/pkg/compilation"
-	"lunchpail.io/pkg/ir/llir"
-)
+import "lunchpail.io/pkg/ir/llir"
 
-func (backend Backend) Up(ir llir.LLIR, opts compilation.Options, verbose bool) error {
+func (backend Backend) Up(ir llir.LLIR, opts llir.Options, verbose bool) error {
 	if err := applyOperation(ir, backend.namespace, "", ApplyIt, opts, verbose); err != nil {
 		return err
 	}

--- a/pkg/be/kubernetes/values.go
+++ b/pkg/be/kubernetes/values.go
@@ -10,7 +10,7 @@ import (
 	k8s "k8s.io/client-go/kubernetes"
 
 	"lunchpail.io/pkg/be/kubernetes/common"
-	"lunchpail.io/pkg/compilation"
+	"lunchpail.io/pkg/ir/llir"
 )
 
 func isOpenShift(clientset *k8s.Clientset) (bool, error) {
@@ -27,7 +27,7 @@ func isOpenShift(clientset *k8s.Clientset) (bool, error) {
 	return false, nil
 }
 
-func k8sOptions(copts compilation.Options) (common.Options, error) {
+func k8sOptions(copts llir.Options) (common.Options, error) {
 	opts := common.Options{Options: copts}
 
 	clientset, _, err := Client()

--- a/pkg/fe/prepare-run.go
+++ b/pkg/fe/prepare-run.go
@@ -21,7 +21,7 @@ type CompileOptions struct {
 }
 
 // TODO move into RestoreOptions
-func valuesFromShrinkwrap(templatePath string, opts compilation.Options) (compilation.Options, error) {
+func valuesFromShrinkwrap(templatePath string, opts compilation.Options) (llir.Options, error) {
 	shrinkwrappedOptions, err := compilation.RestoreOptions(templatePath)
 	if err != nil {
 		return opts, err

--- a/pkg/ir/llir/llir.go
+++ b/pkg/ir/llir/llir.go
@@ -28,13 +28,3 @@ type LLIR struct {
 	// One Component per WorkerPool, one for WorkerStealer, etc.
 	Components []Component
 }
-
-/*func (ir LLIR) Jobs() []Component {
-	jobs := []Component{}
-	for _, c := range ir.Components {
-		if c.IsJob() {
-			jobs = append(jobs, c)
-		}
-	}
-	return jobs
-        }*/

--- a/pkg/ir/llir/options.go
+++ b/pkg/ir/llir/options.go
@@ -1,0 +1,5 @@
+package llir
+
+import "lunchpail.io/pkg/compilation"
+
+type Options = compilation.Options


### PR DESCRIPTION
this avoids having to import pkg/compilation in addition to important pkg/ir/llir