### PR TITLE
fix: no minio component with external s3

### DIFF
--- a/pkg/fe/linker/configure.go
+++ b/pkg/fe/linker/configure.go
@@ -34,6 +34,7 @@ func Configure(appname, runname, namespace, templatePath string, internalS3Port 
 	if queueSpec.Endpoint == "" {
 		// see charts/workstealer/templates/s3/service... the hostname of the service has a max length
 		runnameMax53 := util.Dns1035(runname + "-minio")
+		queueSpec.Auto = true
 		queueSpec.Port = internalS3Port
 		queueSpec.Endpoint = fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", runnameMax53, namespace, internalS3Port)
 		queueSpec.AccessKey = "lunchpail"

--- a/pkg/fe/transformer/api/minio/lower.go
+++ b/pkg/fe/transformer/api/minio/lower.go
@@ -9,6 +9,10 @@ import (
 )
 
 func Lower(compilationName, runname string, model hlir.AppModel, ir llir.LLIR, opts compilation.Options, verbose bool) (llir.Component, error) {
+	if !ir.Queue.Auto {
+		return nil, nil
+	}
+
 	app, err := transpile(runname, ir)
 	if err != nil {
 		return nil, err

--- a/pkg/fe/transformer/lower.go
+++ b/pkg/fe/transformer/lower.go
@@ -20,6 +20,9 @@ func Lower(compilationName, runname string, model hlir.AppModel, queueSpec queue
 	if err != nil {
 		return llir.LLIR{}, err
 	}
+	if minio != nil {
+		ir.Components = slices.Concat([]llir.Component{minio})
+	}
 
 	apps, err := lowerApplications(compilationName, runname, model, ir, opts, verbose)
 	if err != nil {
@@ -42,7 +45,7 @@ func Lower(compilationName, runname string, model hlir.AppModel, queueSpec queue
 	}
 	ir.AppProvidedKubernetesResources = appProvidedKubernetes
 
-	ir.Components = slices.Concat([]llir.Component{minio}, apps, dispatchers, pools)
+	ir.Components = slices.Concat(ir.Components, apps, dispatchers, pools)
 
 	return ir, nil
 }


### PR DESCRIPTION
When using an external task queue via `--queue`, we want internals3 minio to be disabled and not lowered as a separate component. 