### PR TITLE
feat: port tests/bin/helpers.sh from kubectl logs to lunchpail logs

### DIFF
--- a/cmd/subcommands/logs.go
+++ b/cmd/subcommands/logs.go
@@ -17,6 +17,7 @@ func newLogsCommand() *cobra.Command {
 	var componentsFlag []string
 	var followFlag bool
 	var verboseFlag bool
+	var tailFlag int
 
 	var cmd = &cobra.Command{
 		Use:   "logs",
@@ -27,6 +28,7 @@ func newLogsCommand() *cobra.Command {
 	cmd.Flags().StringSliceVarP(&componentsFlag, "component", "c", []string{"workers"}, "Components to track (workers|dispatcher|workstealer)")
 	cmd.Flags().BoolVarP(&followFlag, "follow", "f", false, "Stream the logs")
 	cmd.Flags().BoolVarP(&verboseFlag, "verbose", "v", false, "Verbose output")
+	cmd.Flags().IntVarP(&tailFlag, "tail", "T", -1, "Lines of recent log file to display, with -1 showing all available log data")
 	tgtOpts := addTargetOptions(cmd)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
@@ -58,7 +60,7 @@ func newLogsCommand() *cobra.Command {
 			}
 		}
 
-		return observe.Logs(maybeRun, backend, observe.LogsOptions{Follow: followFlag, Verbose: verboseFlag, Components: comps})
+		return observe.Logs(maybeRun, backend, observe.LogsOptions{Follow: followFlag, Tail: tailFlag, Verbose: verboseFlag, Components: comps})
 	}
 
 	return cmd

--- a/hack/setup/cli.sh
+++ b/hack/setup/cli.sh
@@ -5,7 +5,7 @@ set -e
 SCRIPTDIR=$(cd $(dirname "$0") && pwd)
 
 TOP="$SCRIPTDIR"/../..
-if [[ -d ./cmd ]]
+if [ -d ./cmd ]
 then TOP=$(pwd)
 fi
 

--- a/pkg/be/ibmcloud/logs.go
+++ b/pkg/be/ibmcloud/logs.go
@@ -7,6 +7,6 @@ import (
 )
 
 // Stream logs from a given Component to the given channel
-func (streamer Streamer) ComponentLogs(runname string, component lunchpail.Component, follow, verbose bool) error {
+func (streamer Streamer) ComponentLogs(runname string, component lunchpail.Component, tail int, follow, verbose bool) error {
 	return fmt.Errorf("Unsupported operation: 'ComponentLogs'")
 }

--- a/pkg/be/kubernetes/logs.go
+++ b/pkg/be/kubernetes/logs.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 
@@ -38,7 +39,7 @@ func (streamer Streamer) podLogs(podName string, component lunchpail.Component, 
 }
 
 // TODO port this to use client-go
-func (streamer Streamer) ComponentLogs(runname string, component lunchpail.Component, follow, verbose bool) error {
+func (streamer Streamer) ComponentLogs(runname string, component lunchpail.Component, tail int, follow, verbose bool) error {
 	containers := "main"
 	runSelector := ",app.kubernetes.io/instance=" + runname
 
@@ -48,7 +49,7 @@ func (streamer Streamer) ComponentLogs(runname string, component lunchpail.Compo
 	}
 
 	selector := "app.kubernetes.io/component=" + string(component) + runSelector
-	cmdline := "kubectl logs -n " + streamer.backend.namespace + " -l " + selector + " --tail=-1 " + followFlag + " -c " + containers + " --max-log-requests=99 | grep -v 'workerpool worker'"
+	cmdline := "kubectl logs -n " + streamer.backend.namespace + " -l " + selector + " --tail=" + strconv.Itoa(tail) + " " + followFlag + " -c " + containers + " --max-log-requests=99 | grep -v 'workerpool worker'"
 
 	if verbose {
 		fmt.Fprintf(os.Stderr, "Tracking logs of component=%s\n", component)

--- a/pkg/be/streamer/streamer.go
+++ b/pkg/be/streamer/streamer.go
@@ -23,5 +23,5 @@ type Streamer interface {
 	QueueStats(runname string, opts qstat.Options) (chan qstat.Model, *errgroup.Group, error)
 
 	// Stream logs from a given Component to os.Stdout
-	ComponentLogs(runname string, component lunchpail.Component, follow, verbose bool) error
+	ComponentLogs(runname string, component lunchpail.Component, tail int, follow, verbose bool) error
 }

--- a/pkg/observe/logs.go
+++ b/pkg/observe/logs.go
@@ -13,6 +13,7 @@ import (
 )
 
 type LogsOptions struct {
+	Tail       int
 	Follow     bool
 	Verbose    bool
 	Components []lunchpail.Component
@@ -35,7 +36,7 @@ func Logs(runnameIn string, backend be.Backend, opts LogsOptions) error {
 
 	for _, component := range opts.Components {
 		group.Go(func() error {
-			return backend.Streamer().ComponentLogs(runname, component, opts.Follow, opts.Verbose)
+			return backend.Streamer().ComponentLogs(runname, component, opts.Tail, opts.Follow, opts.Verbose)
 		})
 	}
 

--- a/tests/bin/deploy-tests.sh
+++ b/tests/bin/deploy-tests.sh
@@ -25,11 +25,7 @@ if which lspci && lspci | grep -iq nvidia; then
     GPU="--set supportsGpu=true"
 fi
 
-appname="${4-$1}"
-TARGET="$TOP"/builds/test/$appname
-rm -rf "$TARGET"
-
-echo "$(tput setaf 2)Deploying test Runs for arch=$ARCH$(tput sgr0) target=$TARGET $HELM_INSTALL_FLAGS"
+echo "$(tput setaf 2)Deploying test Runs for arch=$ARCH$(tput sgr0) testapp=$testapp $HELM_INSTALL_FLAGS"
 
 if [[ -n "$3" ]]
 then branch="-b $3"
@@ -42,9 +38,6 @@ then
 fi
 
 "$TOP"/hack/setup/cli.sh /tmp/lunchpail
-
-mkdir -p "$TARGET"
-testapp="$TARGET"/test
 
 # Allows us to capture workstealer info before it auto-terminates
 export LUNCHPAIL_SLEEP_BEFORE_EXIT=10

--- a/tests/bin/run.sh
+++ b/tests/bin/run.sh
@@ -67,6 +67,12 @@ then
         TEST_NAME=$testname "$1"/preinit.sh
     fi
 
+    export appname="${deployname-$testname}"
+    export TARGET="$TOP"/builds/test/$appname
+    export testapp="$TARGET"/test
+    rm -rf "$TARGET"
+    mkdir -p "$TARGET"
+
     if [[ -n "$expectCompilationFailure" ]]
     then
         set +e

--- a/tests/bin/undeploy-tests.sh
+++ b/tests/bin/undeploy-tests.sh
@@ -26,7 +26,10 @@ then
     then "$TOP"/builds/test/"$appname"/test down -v
     else
         for dir in $(ls -t "$TOP"/builds/test)
-        do "$TOP"/builds/test/"$dir"/test down -v &
+        do
+            if [ -f "$TOP"/builds/test/"$dir"/test ]
+            then "$TOP"/builds/test/"$dir"/test down -v &
+            fi
         done
 
         wait


### PR DESCRIPTION
This also adds a `--tail` option to the lunchpail logs command.