### PR TITLE
test: eliminate watch from helpers.sh

### DIFF
--- a/pkg/fe/transformer/api/minio/transpile.go
+++ b/pkg/fe/transformer/api/minio/transpile.go
@@ -35,7 +35,7 @@ func transpile(runname string, ir llir.LLIR) (hlir.Application, error) {
 	app.Spec.Env["LUNCHPAIL_QUEUE_PREFIX"] = prefixExcludingBucket
 
 	// Helps with tests. see ./minio.sh
-	app.Spec.Env["LUNCHPAIL_SLEEP_BEFORE_EXIT"] = "5"
+	app.Spec.Env["LUNCHPAIL_SLEEP_BEFORE_EXIT"] = "10"
 
 	return app, nil
 }

--- a/tests/bin/ci.sh
+++ b/tests/bin/ci.sh
@@ -19,12 +19,11 @@ TOP="$SCRIPTDIR"/../..
 
 . "$SCRIPTDIR"/helpers.sh
 
-# On ctrl+c, kill the subprocesses that `watch` may have launched
+# On ctrl+c, kill the subprocesses that may have launched
 trap "pkill -P $$" SIGINT
 
 undeploy
 up
-watch
 
 #
 # Iterate over the tests/* directory

--- a/tests/bin/helpers.sh
+++ b/tests/bin/helpers.sh
@@ -280,7 +280,3 @@ function deploy {
 function undeploy {
     ("$SCRIPTDIR"/undeploy-tests.sh $@ || exit 0)
 }
-
-function watch {
-    kubectl get pod --show-kind -A --watch &
-}


### PR DESCRIPTION
this isn't particularly helpful at this point.
this removes another use of kubectl in helpers.sh