### PR TITLE
feat: lunchpail run instances

### DIFF
--- a/cmd/options/components.go
+++ b/cmd/options/components.go
@@ -1,0 +1,15 @@
+package options
+
+import (
+	"github.com/spf13/cobra"
+
+	"lunchpail.io/pkg/lunchpail"
+)
+
+func AddComponentOption(cmd *cobra.Command) *lunchpail.Component {
+	var component lunchpail.Component
+
+	cmd.Flags().VarP(&component, "component", "c", "Component to track")
+
+	return &component
+}

--- a/cmd/options/target.go
+++ b/cmd/options/target.go
@@ -1,6 +1,6 @@
 //go:build full || deploy || manage || observe
 
-package subcommands
+package options
 
 import (
 	"github.com/spf13/cobra"
@@ -9,10 +9,8 @@ import (
 	"lunchpail.io/pkg/compilation"
 )
 
-type TargetOptions = be.TargetOptions
-
-func addTargetOptions(cmd *cobra.Command) *TargetOptions {
-	options := TargetOptions{TargetPlatform: be.Kubernetes}
+func AddTargetOptions(cmd *cobra.Command) *be.TargetOptions {
+	options := be.TargetOptions{TargetPlatform: be.Kubernetes}
 
 	if compilation.IsCompiled() {
 		// by default, we use Namespace == app name

--- a/cmd/subcommands/cpu.go
+++ b/cmd/subcommands/cpu.go
@@ -5,6 +5,7 @@ package subcommands
 import (
 	"github.com/spf13/cobra"
 
+	"lunchpail.io/cmd/options"
 	"lunchpail.io/pkg/be"
 	"lunchpail.io/pkg/compilation"
 	"lunchpail.io/pkg/observe/cpu"
@@ -22,7 +23,7 @@ func Newcmd() *cobra.Command {
 
 	cmd.Flags().BoolVarP(&verboseFlag, "verbose", "v", false, "Verbose output")
 	cmd.Flags().IntVarP(&intervalSecondsFlag, "interval", "i", 2, "Sampling interval")
-	tgtOpts := addTargetOptions(cmd)
+	tgtOpts := options.AddTargetOptions(cmd)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		maybeRun := ""

--- a/cmd/subcommands/down.go
+++ b/cmd/subcommands/down.go
@@ -5,6 +5,7 @@ package subcommands
 import (
 	"github.com/spf13/cobra"
 
+	"lunchpail.io/cmd/options"
 	"lunchpail.io/pkg/be"
 	"lunchpail.io/pkg/boot"
 	"lunchpail.io/pkg/compilation"
@@ -29,7 +30,7 @@ func newDownCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&apiKey, "api-key", "a", "", "IBM Cloud api key")
 	cmd.Flags().BoolVarP(&deleteCloudResourcesFlag, "delete-cloud-resources", "D", false, "Delete all associated cloud resources and the virtual instance. If not enabled, the instance will only be stopped")
 
-	tgtOpts := addTargetOptions(cmd)
+	tgtOpts := options.AddTargetOptions(cmd)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		backend, err := be.New(*tgtOpts, compilation.Options{ApiKey: apiKey}) // TODO compilation.Options

--- a/cmd/subcommands/logs.go
+++ b/cmd/subcommands/logs.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"lunchpail.io/cmd/options"
 	"lunchpail.io/pkg/be"
 	"lunchpail.io/pkg/compilation"
 	comp "lunchpail.io/pkg/lunchpail"
@@ -29,7 +30,7 @@ func newLogsCommand() *cobra.Command {
 	cmd.Flags().BoolVarP(&followFlag, "follow", "f", false, "Stream the logs")
 	cmd.Flags().BoolVarP(&verboseFlag, "verbose", "v", false, "Verbose output")
 	cmd.Flags().IntVarP(&tailFlag, "tail", "T", -1, "Lines of recent log file to display, with -1 showing all available log data")
-	tgtOpts := addTargetOptions(cmd)
+	tgtOpts := options.AddTargetOptions(cmd)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		maybeRun := ""

--- a/cmd/subcommands/qlast.go
+++ b/cmd/subcommands/qlast.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"lunchpail.io/cmd/options"
 	"lunchpail.io/pkg/be"
 	"lunchpail.io/pkg/compilation"
 	"lunchpail.io/pkg/observe/qstat"
@@ -19,7 +20,7 @@ func newQlastCommand() *cobra.Command {
 		Args:  cobra.MatchAll(cobra.MinimumNArgs(1), cobra.OnlyValidArgs),
 	}
 
-	tgtOpts := addTargetOptions(cmd)
+	tgtOpts := options.AddTargetOptions(cmd)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		marker := args[0]

--- a/cmd/subcommands/qstat.go
+++ b/cmd/subcommands/qstat.go
@@ -4,6 +4,8 @@ package subcommands
 
 import (
 	"github.com/spf13/cobra"
+
+	"lunchpail.io/cmd/options"
 	"lunchpail.io/pkg/be"
 	"lunchpail.io/pkg/compilation"
 	"lunchpail.io/pkg/observe/qstat"
@@ -24,7 +26,7 @@ func newQstatCommand() *cobra.Command {
 	cmd.Flags().Int64VarP(&tailFlag, "tail", "T", -1, "Number of lines to tail")
 	cmd.Flags().BoolVarP(&verboseFlag, "verbose", "v", false, "Verbose output")
 	cmd.Flags().BoolVarP(&quietFlag, "quiet", "q", false, "Silence extraneous output")
-	tgtOpts := addTargetOptions(cmd)
+	tgtOpts := options.AddTargetOptions(cmd)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		maybeRun := ""

--- a/cmd/subcommands/run.go
+++ b/cmd/subcommands/run.go
@@ -1,0 +1,23 @@
+//go:build full || observe
+
+package subcommands
+
+import (
+	"github.com/spf13/cobra"
+
+	"lunchpail.io/cmd/subcommands/run"
+	"lunchpail.io/pkg/compilation"
+)
+
+func init() {
+	if compilation.IsCompiled() {
+		cmd := &cobra.Command{
+			Use:   "run",
+			Short: "Commands related to runs",
+		}
+
+		rootCmd.AddCommand(cmd)
+		cmd.AddCommand(run.List())
+		cmd.AddCommand(run.Instances())
+	}
+}

--- a/cmd/subcommands/run/instances.go
+++ b/cmd/subcommands/run/instances.go
@@ -1,0 +1,51 @@
+//go:build full || observe
+
+package run
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"lunchpail.io/cmd/options"
+	"lunchpail.io/pkg/be"
+	"lunchpail.io/pkg/be/runs/util"
+	"lunchpail.io/pkg/compilation"
+)
+
+func Instances() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   "instances",
+		Short: "Report the number of instances of a given component",
+	}
+
+	tgtOpts := options.AddTargetOptions(cmd)
+	component := options.AddComponentOption(cmd)
+	cmd.MarkFlagRequired("component")
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		backend, err := be.New(*tgtOpts, compilation.Options{}) // TODO compilation.Options
+		if err != nil {
+			return err
+		}
+
+		runname := ""
+		if len(args) > 0 {
+			runname = args[0]
+		} else if r, err := util.Singleton(backend); err != nil {
+			return err
+		} else {
+			runname = r.Name
+		}
+
+		count, err := backend.InstanceCount(*component, runname)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("%d\n", count)
+
+		return nil
+	}
+
+	return cmd
+}

--- a/cmd/subcommands/run/list.go
+++ b/cmd/subcommands/run/list.go
@@ -1,28 +1,29 @@
 //go:build full || observe
 
-package subcommands
+package run
 
 import (
 	"fmt"
 
 	"github.com/spf13/cobra"
 
+	"lunchpail.io/cmd/options"
 	"lunchpail.io/pkg/be"
 	"lunchpail.io/pkg/be/runs"
 	"lunchpail.io/pkg/compilation"
 )
 
-func newRunsCommand() *cobra.Command {
+func List() *cobra.Command {
 	var name bool
 	var latest bool
 
 	var cmd = &cobra.Command{
-		Use:   "runs",
+		Use:   "list",
 		Short: "List recent runs",
 	}
 	cmd.Flags().BoolVarP(&name, "name", "N", false, "Show only the run name")
 	cmd.Flags().BoolVarP(&latest, "latest", "l", false, "Show only the most recent run")
-	tgtOpts := addTargetOptions(cmd)
+	tgtOpts := options.AddTargetOptions(cmd)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		backend, err := be.New(*tgtOpts, compilation.Options{}) // TODO compilation.Options
@@ -39,12 +40,6 @@ func newRunsCommand() *cobra.Command {
 	}
 
 	return cmd
-}
-
-func init() {
-	if compilation.IsCompiled() {
-		rootCmd.AddCommand(newRunsCommand())
-	}
 }
 
 // TODO move to a pkg/observe/runs/ui?

--- a/cmd/subcommands/status.go
+++ b/cmd/subcommands/status.go
@@ -5,6 +5,7 @@ package subcommands
 import (
 	"github.com/spf13/cobra"
 
+	"lunchpail.io/cmd/options"
 	"lunchpail.io/pkg/be"
 	"lunchpail.io/pkg/compilation"
 	"lunchpail.io/pkg/observe/status"
@@ -32,7 +33,7 @@ func newStatusCommand() *cobra.Command {
 	// interval for polling cpu etc.
 	cmd.Flags().IntVarP(&intervalFlag, "interval", "i", 5, "Polling interval in seconds for resource utilization stats")
 
-	tgtOpts := addTargetOptions(cmd)
+	tgtOpts := options.AddTargetOptions(cmd)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		maybeRun := ""

--- a/cmd/subcommands/up.go
+++ b/cmd/subcommands/up.go
@@ -3,6 +3,7 @@
 package subcommands
 
 import (
+	"lunchpail.io/cmd/options"
 	"lunchpail.io/pkg/be"
 	"lunchpail.io/pkg/boot"
 	"lunchpail.io/pkg/compilation"
@@ -60,7 +61,7 @@ func newUpCmd() *cobra.Command {
 
 	cmd.Flags().SortFlags = false
 	appOpts := addCompilationOptions(cmd, true)
-	tgtOpts := addTargetOptions(cmd)
+	tgtOpts := options.AddTargetOptions(cmd)
 	cmd.Flags().BoolVarP(&dryrunFlag, "dry-run", "", false, "Emit application yaml to stdout")
 	cmd.Flags().BoolVarP(&verboseFlag, "verbose", "v", false, "Verbose output")
 	cmd.Flags().BoolVarP(&watchFlag, "watch", "w", watchFlag, "After deployment, watch for status updates")

--- a/pkg/be/backend.go
+++ b/pkg/be/backend.go
@@ -4,6 +4,7 @@ import (
 	"lunchpail.io/pkg/be/runs"
 	"lunchpail.io/pkg/be/streamer"
 	"lunchpail.io/pkg/ir/llir"
+	"lunchpail.io/pkg/lunchpail"
 )
 
 type Backend interface {
@@ -24,6 +25,9 @@ type Backend interface {
 
 	// List deployed runs
 	ListRuns() ([]runs.Run, error)
+
+	// Number of instances of the given component for the given run
+	InstanceCount(c lunchpail.Component, runname string) (int, error)
 
 	// Return a streamer
 	Streamer() streamer.Streamer

--- a/pkg/be/ibmcloud/instances.go
+++ b/pkg/be/ibmcloud/instances.go
@@ -1,0 +1,10 @@
+package ibmcloud
+
+import (
+	"lunchpail.io/pkg/lunchpail"
+)
+
+// Number of instances of the given component for the given run
+func (backend Backend) InstanceCount(c lunchpail.Component, runname string) (int, error) {
+	return 0, nil
+}

--- a/pkg/be/kubernetes/instances.go
+++ b/pkg/be/kubernetes/instances.go
@@ -1,0 +1,27 @@
+package kubernetes
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"lunchpail.io/pkg/lunchpail"
+)
+
+// Number of instances of the given component for the given run
+func (backend Backend) InstanceCount(component lunchpail.Component, runname string) (int, error) {
+	c, _, err := Client()
+	if err != nil {
+		return 0, err
+	}
+
+	pods, err := c.CoreV1().Pods(backend.namespace).List(context.Background(), metav1.ListOptions{
+		FieldSelector: "status.phase=Running",
+		LabelSelector: "app.kubernetes.io/component=" + string(component) + ",app.kubernetes.io/instance=" + runname,
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	return len(pods.Items), nil
+}

--- a/pkg/lunchpail/component.go
+++ b/pkg/lunchpail/component.go
@@ -1,5 +1,7 @@
 package lunchpail
 
+import "fmt"
+
 type Component string
 
 const (
@@ -20,4 +22,39 @@ func ComponentShortName(c Component) string {
 	default:
 		return string(c)
 	}
+}
+
+func lookup(maybe string) (Component, error) {
+	switch maybe {
+	case string(WorkersComponent):
+		return WorkersComponent, nil
+	case string(DispatcherComponent):
+		return DispatcherComponent, nil
+	case string(WorkStealerComponent):
+		return WorkStealerComponent, nil
+	case string(MinioComponent):
+		return MinioComponent, nil
+	}
+
+	return "", fmt.Errorf("Unsupported component %s\n", maybe)
+}
+
+// String is used both by fmt.Print and by Cobra in help text
+func (c *Component) String() string {
+	return string(*c)
+}
+
+// Set must have pointer receiver so it doesn't change the value of a copy
+func (c *Component) Set(v string) error {
+	cc, err := lookup(v)
+	if err != nil {
+		return err
+	}
+	*c = cc
+	return nil
+}
+
+// Type is only used in help text
+func (c *Component) Type() string {
+	return "Component"
 }

--- a/tests/bin/helpers.sh
+++ b/tests/bin/helpers.sh
@@ -68,7 +68,7 @@ function waitForIt {
         done
     done
 
-    local run_name=$($testapp runs -n $ns --latest --name)
+    local run_name=$($testapp run list -n $ns --latest --name)
     echo "✅ PASS run-controller found run test=$name run_name=$run_name"
 
     if [[ "$api" != "workqueue" ]] || [[ ${NUM_DESIRED_OUTPUTS:-1} = 0 ]]
@@ -145,7 +145,7 @@ function waitForIt {
         echo "Checking that no workerdispatchers remain running"
         while true
         do
-            nRunningWorkDispatchers=$(kubectl get --ignore-not-found pod -l app.kubernetes.io/component=workdispatcher,app.kubernetes.io/instance=$run_name -n $ns --field-selector status.phase=Running --no-headers | wc -l | xargs)
+            nRunningWorkDispatchers=$($testapp run instances --component workdispatcher -n $ns)
             if [[ $nRunningWorkDispatchers == 0 ]]
             then echo "✅ PASS run-controller test=$name no workdispatchers remain running" && break
             else echo "$nRunningWorkDispatchers workdispatcher(s) remaining running" && sleep 2
@@ -155,7 +155,7 @@ function waitForIt {
         echo "Checking that no workers remain running"
         while true
         do
-            nRunningWorkers=$(kubectl get --ignore-not-found pod -l app.kubernetes.io/component=workerpool,app.kubernetes.io/instance=$run_name -n $ns --field-selector status.phase=Running --no-headers | wc -l | xargs)
+            nRunningWorkers=$($testapp run instances --component workerpool -n $ns)
             if [[ $nRunningWorkers == 0 ]]
             then echo "✅ PASS run-controller test=$name no workers remain running" && break
             else echo "$nRunningWorkers worker(s) remaining running" && sleep 2
@@ -165,7 +165,7 @@ function waitForIt {
         echo "Checking that no workerstealers remain running"
         while true
         do
-            nRunningWorkstealers=$(kubectl get pod --ignore-not-found -l app.kubernetes.io/component=workstealer,app.kubernetes.io/instance=$run_name -n $ns --field-selector status.phase=Running --no-headers | wc -l | xargs)
+            nRunningWorkstealers=$($testapp run instances --component workstealer -n $ns)
             if [[ $nRunningWorkstealers == 0 ]]
             then echo "✅ PASS run-controller test=$name no workstealers remain running" && break
             else echo "$nRunningWorkstealers workstealer(s) remaining running" && sleep 2
@@ -175,7 +175,7 @@ function waitForIt {
         echo "Checking that no minios remain running"
         while true
         do
-            nRunningMinios=$(kubectl get pod --ignore-not-found -l app.kubernetes.io/component=minio,app.kubernetes.io/instance=$run_name -n $ns --field-selector status.phase=Running --no-headers | wc -l | xargs)
+            nRunningMinios=$($testapp run instances --component minio -n $ns)
             if [[ $nRunningMinios == 0 ]]
             then echo "✅ PASS run-controller test=$name no minios remain running" && break
             else echo "$nRunningMinios minio(s) remaining running" && sleep 2
@@ -264,7 +264,7 @@ function waitForUnassignedAndOutbox {
     done
     echo "✅ PASS run-controller run test $name"
 
-    local run_name=$($testapp runs -n $ns --latest --name)
+    local run_name=$($testapp run list -n $ns --latest --name)
     echo "✅ PASS run-controller found run test=$name"
 }
 


### PR DESCRIPTION
- this reports the number of instances of a given component
- also changes lunchpail runs to lunchpail run list
- also updates helpers.sh to use it, which removes another use of kubectl in helpers.sh