### PR TITLE
feat: update qin to support running in compiled mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	k8s.io/api v0.30.3
 	k8s.io/apimachinery v0.30.3
 	k8s.io/client-go v0.30.3
+	k8s.io/kubernetes v1.31.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -684,6 +684,8 @@ k8s.io/kube-openapi v0.0.0-20240808142205-8e686545bdb8 h1:1Wof1cGQgA5pqgo8MxKPtf
 k8s.io/kube-openapi v0.0.0-20240808142205-8e686545bdb8/go.mod h1:Os6V6dZwLNii3vxFpxcNaTmH8LJJBkOTg1N0tOA0fvA=
 k8s.io/kubectl v0.30.3 h1:YIBBvMdTW0xcDpmrOBzcpUVsn+zOgjMYIu7kAq+yqiI=
 k8s.io/kubectl v0.30.3/go.mod h1:IcR0I9RN2+zzTRUa1BzZCm4oM0NLOawE6RzlDvd1Fpo=
+k8s.io/kubernetes v1.31.0 h1:sYAB12TTWexXKp4RxqJMm/7EC+P0mNOgn4Xdj5eu7HM=
+k8s.io/kubernetes v1.31.0/go.mod h1:UTpGn7nxrUrPWw5hNIYTAjodcWIvLakgHpLtfrr6GC8=
 k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 h1:pUdcCO1Lk/tbT5ztQWOBi5HBgbBP1J8+AsQnQCKsi8A=
 k8s.io/utils v0.0.0-20240711033017-18e509b52bc8/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 oras.land/oras-go v1.2.6 h1:z8cmxQXBU8yZ4mkytWqXfo6tZcamPwjsuxYU81xJ8Lk=

--- a/pkg/be/kubernetes/wait.go
+++ b/pkg/be/kubernetes/wait.go
@@ -1,0 +1,37 @@
+package kubernetes
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/pkg/client/conditions"
+)
+
+// return a condition function that indicates whether the given pod is
+// currently running
+func isPodRunning(ctx context.Context, c kubernetes.Interface, podName, namespace string) wait.ConditionFunc {
+	return func() (bool, error) {
+		pod, err := c.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		switch pod.Status.Phase {
+		case v1.PodRunning:
+			return true, nil
+		case v1.PodFailed, v1.PodSucceeded:
+			return false, conditions.ErrPodCompleted
+		}
+		return false, nil
+	}
+}
+
+// Poll up to timeout seconds for pod to enter running state.
+// Returns an error if the pod never enters the running state.
+func waitForPodRunning(ctx context.Context, c kubernetes.Interface, namespace, podName string, timeout time.Duration) error {
+	return wait.PollImmediate(time.Second, timeout, isPodRunning(ctx, c, podName, namespace))
+}

--- a/pkg/runtime/queue/copyin.go
+++ b/pkg/runtime/queue/copyin.go
@@ -1,19 +1,23 @@
 package queue
 
 import (
+	"context"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"lunchpail.io/pkg/be"
 )
 
-func CopyIn(srcDir, bucket string) error {
-	s3, err := NewS3Client()
+func CopyIn(ctx context.Context, backend be.Backend, runname, srcDir, bucket string) error {
+	s3, stop, err := NewS3ClientForRun(ctx, backend, runname)
 	if err != nil {
 		return err
 	}
+	defer stop()
 
 	fmt.Fprintf(os.Stderr, "Preparing upload with mkdirp on s3 bucket=%s\n", bucket)
 	if err := s3.Mkdirp(bucket); err != nil {

--- a/tests/bin/add-data.sh
+++ b/tests/bin/add-data.sh
@@ -27,8 +27,9 @@ for bucket_path in $@; do
         done
         
         set -x
-        kubectl cp -c main $bucket_path $pod:/tmp/$bucket -n $NAMESPACE
-        kubectl exec $pod -n $NAMESPACE -c main -- sh -c "lunchpail qin /tmp/$bucket $bucket && rm -rf /tmp/$bucket"
+#        kubectl cp -c main $bucket_path $pod:/tmp/$bucket -n $NAMESPACE
+#        kubectl exec $pod -n $NAMESPACE -c main -- sh -c "lunchpail qin /tmp/$bucket $bucket && rm -rf /tmp/$bucket"
+        $testapp qin $bucket_path $bucket
         set +x
     fi
 done

--- a/tests/bin/run.sh
+++ b/tests/bin/run.sh
@@ -93,10 +93,6 @@ then
         deploy $testname $app $branch $deployname
     fi
 
-    # if [[ $(basename $1) = test7d ]]
-    # then kubectl logs deploy/run-controller -n $(basename $1) -f &
-    # fi
-
     namespace=${deployname-$testname}
 
     if [[ -e "$1"/init.sh ]]; then


### PR DESCRIPTION
- fixes be/kubernetes/portforward to wait for the target pod to be ready
- removes hopefully the final use of kubectl in tests/bin (we had missed add-data.sh in the previous PRs)