### PR TITLE
fix: eliminate rclone CLI dependence from tests

### DIFF
--- a/pkg/fe/linker/queue/rclone.go
+++ b/pkg/fe/linker/queue/rclone.go
@@ -2,6 +2,7 @@ package queue
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -24,6 +25,12 @@ func SpecFromRcloneRemoteName(remoteName, bucket, runname string, internalS3Port
 		"",             // SecretKey
 	}
 
+	if os.Getenv("RCLONE_CONFIG") != "" {
+		// sigh, rclone doesn't seem to support this except at the level of the rclone CLI
+		if err := rcloneConfig.SetConfigPath(os.Getenv("RCLONE_CONFIG")); err != nil {
+			return false, Spec{}, err
+		}
+	}
 	rcloneConfigFile.Install() // otherwise, DumpRcRemote() yields an empty map
 	config := rcloneConfig.DumpRcRemote(remoteName)
 

--- a/tests/bin/add-data.sh
+++ b/tests/bin/add-data.sh
@@ -27,8 +27,6 @@ for bucket_path in $@; do
         done
         
         set -x
-#        kubectl cp -c main $bucket_path $pod:/tmp/$bucket -n $NAMESPACE
-#        kubectl exec $pod -n $NAMESPACE -c main -- sh -c "lunchpail qin /tmp/$bucket $bucket && rm -rf /tmp/$bucket"
         $testapp qin $bucket_path $bucket
         set +x
     fi

--- a/tests/bin/run.sh
+++ b/tests/bin/run.sh
@@ -23,6 +23,9 @@ then
     exit 1
 fi
 
+# in case tests want to populate an rclone config
+export RCLONE_CONFIG=$(mktemp)
+
 # Skip disabled tests
 if [[ -e "$1"/.disabled ]]
 then

--- a/tests/tests/test7-security-context/preinit.sh
+++ b/tests/tests/test7-security-context/preinit.sh
@@ -1,5 +1,4 @@
-rclone config delete rcloneremotetest
-cat <<'EOF' >> ~/.config/rclone/rclone.conf 
+cat <<'EOF' >> $RCLONE_CONFIG
 [rcloneremotetest]
 type = s3
 provider = Other

--- a/tests/tests/test7-wait/preinit.sh
+++ b/tests/tests/test7-wait/preinit.sh
@@ -1,5 +1,4 @@
-rclone config delete rcloneremotetest
-cat <<'EOF' >> ~/.config/rclone/rclone.conf 
+cat <<'EOF' >> $RCLONE_CONFIG
 [rcloneremotetest]
 type = s3
 provider = Other

--- a/tests/tests/test7/preinit.sh
+++ b/tests/tests/test7/preinit.sh
@@ -1,5 +1,4 @@
-rclone config delete rcloneremotetest
-cat <<'EOF' >> ~/.config/rclone/rclone.conf 
+cat <<'EOF' >> $RCLONE_CONFIG
 [rcloneremotetest]
 type = s3
 provider = Other

--- a/tests/tests/test7b/preinit.sh
+++ b/tests/tests/test7b/preinit.sh
@@ -1,5 +1,4 @@
-rclone config delete rcloneremotetest
-cat <<'EOF' >> ~/.config/rclone/rclone.conf 
+cat <<'EOF' >> $RCLONE_CONFIG
 [rcloneremotetest]
 type = s3
 provider = Other

--- a/tests/tests/test7f/preinit.sh
+++ b/tests/tests/test7f/preinit.sh
@@ -1,5 +1,4 @@
-rclone config delete rcloneremotetest
-cat <<'EOF' >> ~/.config/rclone/rclone.conf 
+cat <<'EOF' >> $RCLONE_CONFIG
 [rcloneremotetest]
 type = s3
 provider = Other


### PR DESCRIPTION
we were using this to update the default rclone config. this updates the test logic to use a per-test rclone config file. this should be safer (we will avoid modifying a non-lunchpail common config file), and makes it easier to eliminate the rclone CLI dependence.