### PR TITLE
fix: minio server command sleeps twice before exit

### DIFF
--- a/cmd/subcommands/minio/server.go
+++ b/cmd/subcommands/minio/server.go
@@ -1,9 +1,6 @@
 package minio
 
 import (
-	"os"
-	"time"
-
 	"github.com/spf13/cobra"
 
 	"lunchpail.io/pkg/runtime/minio"
@@ -16,22 +13,7 @@ func Server() *cobra.Command {
 		Long:  "Run as the minio component",
 		Args:  cobra.MatchAll(cobra.ExactArgs(0), cobra.OnlyValidArgs),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := minio.Server(); err != nil {
-				return err
-			}
-
-			// Tests may want us to sleep a bit, so they
-			// can capture data for validation checks.
-			sleepyTimeStr := os.Getenv("LUNCHPAIL_SLEEP_BEFORE_EXIT")
-			if sleepyTimeStr != "" {
-				sleepyTime, err := time.ParseDuration(sleepyTimeStr + "s")
-				if err != nil {
-					return err
-				}
-				time.Sleep(sleepyTime)
-			}
-
-			return nil
+			return minio.Server()
 		},
 	}
 }


### PR DESCRIPTION
we had one sleep in the cmd and another in the pkg