### PR TITLE
fix: front-end has kubernetes-specific queue endpoint (service address)

### DIFF
--- a/pkg/be/kubernetes/up.go
+++ b/pkg/be/kubernetes/up.go
@@ -1,8 +1,15 @@
 package kubernetes
 
-import "lunchpail.io/pkg/ir/llir"
+import (
+	"fmt"
+
+	"lunchpail.io/pkg/ir/llir"
+	"lunchpail.io/pkg/util"
+)
 
 func (backend Backend) Up(ir llir.LLIR, opts llir.Options, verbose bool) error {
+	ir.Queue = ir.Queue.UpdateEndpoint(fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", util.Dns1035(ir.RunName+"-minio"), backend.namespace, ir.Queue.Port))
+
 	if err := applyOperation(ir, backend.namespace, "", ApplyIt, opts, verbose); err != nil {
 		return err
 	}

--- a/pkg/fe/linker/configure.go
+++ b/pkg/fe/linker/configure.go
@@ -8,7 +8,6 @@ import (
 	"lunchpail.io/pkg/compilation"
 	"lunchpail.io/pkg/fe/linker/queue"
 	"lunchpail.io/pkg/lunchpail"
-	"lunchpail.io/pkg/util"
 )
 
 type ConfigureOptions struct {
@@ -33,10 +32,9 @@ func Configure(appname, runname, namespace, templatePath string, internalS3Port 
 
 	if queueSpec.Endpoint == "" {
 		// see charts/workstealer/templates/s3/service... the hostname of the service has a max length
-		runnameMax53 := util.Dns1035(runname + "-minio")
 		queueSpec.Auto = true
 		queueSpec.Port = internalS3Port
-		queueSpec.Endpoint = fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", runnameMax53, namespace, internalS3Port)
+		queueSpec.Endpoint = fmt.Sprintf("localhost:%d", internalS3Port)
 		queueSpec.AccessKey = "lunchpail"
 		queueSpec.SecretKey = "lunchpail"
 	}

--- a/pkg/fe/linker/queue/spec.go
+++ b/pkg/fe/linker/queue/spec.go
@@ -9,3 +9,8 @@ type Spec struct {
 	AccessKey string
 	SecretKey string
 }
+
+func (spec Spec) UpdateEndpoint(endpoint string) Spec {
+	spec.Endpoint = endpoint
+	return spec
+}


### PR DESCRIPTION
- moves that service address to be/kubernetes
- introduces Queue.UpdateEndpoint() api