### PR TITLE
fix: avoid kubernetes-isms in test rclone config

### DIFF
--- a/pkg/be/kubernetes/shell/template.go
+++ b/pkg/be/kubernetes/shell/template.go
@@ -54,7 +54,7 @@ func Template(ir llir.LLIR, c llir.ShellComponent, namespace string, opts common
 		"lunchpail.instanceName=" + c.InstanceName,
 		"lunchpail.component=" + string(c.Component),
 		"image=" + c.Application.Spec.Image,
-		"command=" + c.Application.Spec.Command,
+		"command=" + updateTestQueueEndpoint(c.Application.Spec.Command, ir.Queue),
 		fmt.Sprintf("lunchpail.runAsJob=%v", c.RunAsJob),
 		// fmt.Sprintf("lunchpail.debug=%v", verbose),
 		"lunchpail.terminationGracePeriodSeconds=" + strconv.Itoa(terminationGracePeriodSeconds),

--- a/pkg/fe/linker/queue/rclone.go
+++ b/pkg/fe/linker/queue/rclone.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-	"strconv"
 	"strings"
 
 	rcloneConfig "github.com/rclone/rclone/fs/config"
@@ -61,36 +60,22 @@ func SpecFromRcloneRemoteName(remoteName, bucket, runname string, internalS3Port
 		spec.SecretKey = s
 	}
 
-	if spec.Endpoint == "" {
+	if spec.Endpoint == "" || spec.Endpoint == "$TEST_QUEUE_ENDPOINT" {
 		spec.Auto = true
 	}
 
-	if strings.Contains(spec.Endpoint, "$TEST_RUN") {
+	if strings.Contains(spec.AccessKey, "$TEST_QUEUE_ACCESSKEY") {
 		// helpful for tests, which want to point to the
 		// internal s3 whose service name isn't known ahead of
 		// time -- it includes the run name
-		spec.Endpoint = strings.Replace(spec.Endpoint, "$TEST_RUN", runname, -1)
+		spec.AccessKey = strings.Replace(spec.AccessKey, "$TEST_QUEUE_ACCESSKEY", "lunchpail", -1)
 	}
 
-	if strings.Contains(spec.Endpoint, "$TEST_PORT") {
+	if strings.Contains(spec.SecretKey, "$TEST_QUEUE_SECRETKEY") {
 		// helpful for tests, which want to point to the
 		// internal s3 whose service name isn't known ahead of
 		// time -- it includes the run name
-		spec.Endpoint = strings.Replace(spec.Endpoint, "$TEST_PORT", strconv.Itoa(internalS3Port), -1)
-	}
-
-	if strings.Contains(spec.AccessKey, "$TEST_ACCESSKEY") {
-		// helpful for tests, which want to point to the
-		// internal s3 whose service name isn't known ahead of
-		// time -- it includes the run name
-		spec.AccessKey = strings.Replace(spec.AccessKey, "$TEST_ACCESSKEY", "lunchpail", -1)
-	}
-
-	if strings.Contains(spec.SecretKey, "$TEST_SECRETKEY") {
-		// helpful for tests, which want to point to the
-		// internal s3 whose service name isn't known ahead of
-		// time -- it includes the run name
-		spec.SecretKey = strings.Replace(spec.SecretKey, "$TEST_SECRETKEY", "lunchpail", -1)
+		spec.SecretKey = strings.Replace(spec.SecretKey, "$TEST_QUEUE_SECRETKEY", "lunchpail", -1)
 	}
 
 	return true, spec, nil

--- a/tests/tests/test7-security-context/preinit.sh
+++ b/tests/tests/test7-security-context/preinit.sh
@@ -1,10 +1,1 @@
-cat <<'EOF' >> $RCLONE_CONFIG
-[rcloneremotetest]
-type = s3
-provider = Other
-env_auth = false
-endpoint = http://$TEST_RUN-minio.test7-security-context.svc.cluster.local:$TEST_PORT
-access_key_id = $TEST_ACCESSKEY
-secret_access_key = $TEST_SECRETKEY
-acl = public-read
-EOF
+../test7/preinit.sh

--- a/tests/tests/test7-wait/preinit.sh
+++ b/tests/tests/test7-wait/preinit.sh
@@ -1,10 +1,1 @@
-cat <<'EOF' >> $RCLONE_CONFIG
-[rcloneremotetest]
-type = s3
-provider = Other
-env_auth = false
-endpoint = http://$TEST_RUN-minio.test7-wait.svc.cluster.local:$TEST_PORT
-access_key_id = $TEST_ACCESSKEY
-secret_access_key = $TEST_SECRETKEY
-acl = public-read
-EOF
+../test7/preinit.sh

--- a/tests/tests/test7/preinit.sh
+++ b/tests/tests/test7/preinit.sh
@@ -3,8 +3,8 @@ cat <<'EOF' >> $RCLONE_CONFIG
 type = s3
 provider = Other
 env_auth = false
-endpoint = http://$TEST_RUN-minio.test7.svc.cluster.local:$TEST_PORT
-access_key_id = $TEST_ACCESSKEY
-secret_access_key = $TEST_SECRETKEY
+endpoint = $TEST_QUEUE_ENDPOINT
+access_key_id = $TEST_QUEUE_ACCESSKEY
+secret_access_key = $TEST_QUEUE_SECRETKEY
 acl = public-read
 EOF

--- a/tests/tests/test7b/preinit.sh
+++ b/tests/tests/test7b/preinit.sh
@@ -1,10 +1,1 @@
-cat <<'EOF' >> $RCLONE_CONFIG
-[rcloneremotetest]
-type = s3
-provider = Other
-env_auth = false
-endpoint = http://$TEST_RUN-minio.test7b.svc.cluster.local:$TEST_PORT
-access_key_id = $TEST_ACCESSKEY
-secret_access_key = $TEST_SECRETKEY
-acl = public-read
-EOF
+../test7/preinit.sh

--- a/tests/tests/test7f/preinit.sh
+++ b/tests/tests/test7f/preinit.sh
@@ -1,10 +1,1 @@
-cat <<'EOF' >> $RCLONE_CONFIG
-[rcloneremotetest]
-type = s3
-provider = Other
-env_auth = false
-endpoint = http://$TEST_RUN-minio.test7f.svc.cluster.local:$TEST_PORT
-access_key_id = $TEST_ACCESSKEY
-secret_access_key = $TEST_SECRETKEY
-acl = public-read
-EOF
+../test7/preinit.sh


### PR DESCRIPTION
this also allows us to avoid having copies of preinit.sh, and instead we can have one and share via symlink