### PR TITLE
feat: allow --target to be provided at compile time

### DIFF
--- a/cmd/options/compile.go
+++ b/cmd/options/compile.go
@@ -1,0 +1,42 @@
+//go:build full || compile
+
+package options
+
+import (
+	"github.com/spf13/cobra"
+
+	"lunchpail.io/pkg/compilation"
+)
+
+func AddCompilationOptions(cmd *cobra.Command) (*compilation.Options, error) {
+	var options compilation.Options
+
+	if compilation.IsCompiled() {
+		if o, err := compilation.RestoreOptions(); err != nil {
+			return nil, err
+		} else {
+			options = o
+		}
+	}
+
+	cmd.Flags().StringVarP(&options.ImagePullSecret, "image-pull-secret", "s", options.ImagePullSecret, "Of the form <user>:<token>@ghcr.io")
+	cmd.Flags().StringVar(&options.Queue, "queue", options.Queue, "Use the queue defined by this Secret (data: accessKeyID, secretAccessKey, endpoint)")
+	cmd.Flags().BoolVar(&options.HasGpuSupport, "gpu", options.HasGpuSupport, "Run with GPUs (if supported by the application)")
+
+	cmd.Flags().StringSliceVar(&[]string{}, "set", []string{}, "[Advanced] override specific template values")
+	cmd.Flags().StringSliceVar(&[]string{}, "set-file", []string{}, "[Advanced] override specific template values with content from a file")
+
+	cmd.Flags().StringVarP(&options.ApiKey, "api-key", "a", options.ApiKey, "IBM Cloud api key")
+	cmd.Flags().StringVar(&options.ResourceGroupID, "resource-group-id", options.ResourceGroupID, "Identifier of a Cloud resource group to contain the instance(s)")
+	//Todo: allow selecting existing ssh key?
+	cmd.Flags().StringVar(&options.SSHKeyType, "ssh-key-type", options.SSHKeyType, "SSH key type [rsa, ed25519]")
+	cmd.Flags().StringVar(&options.PublicSSHKey, "public-ssh-key", options.PublicSSHKey, "An existing or new SSH public key to identify user on the instance")
+	cmd.Flags().StringVar(&options.Zone, "zone", options.Zone, "A location to host the instance")
+	cmd.Flags().StringVar(&options.Profile, "profile", options.Profile, "An instance profile type to choose size and capability of the instance")
+	//TODO: make public image as default
+	cmd.Flags().StringVar(&options.ImageID, "image-id", options.ImageID, "Identifier of a catalog or custom image to be used for instance creation")
+	cmd.Flags().BoolVarP(&options.CreateNamespace, "create-namespace", "N", options.CreateNamespace, "Create a new namespace, if needed")
+
+	addTargetOptionsTo(cmd, &options)
+	return &options, nil
+}

--- a/cmd/options/target.go
+++ b/cmd/options/target.go
@@ -5,20 +5,27 @@ package options
 import (
 	"github.com/spf13/cobra"
 
-	"lunchpail.io/pkg/be"
+	"lunchpail.io/pkg/be/target"
 	"lunchpail.io/pkg/compilation"
 )
 
-func AddTargetOptions(cmd *cobra.Command) *be.TargetOptions {
-	options := be.TargetOptions{TargetPlatform: be.Kubernetes}
+func AddTargetOptions(cmd *cobra.Command) *compilation.TargetOptions {
+	return addTargetOptionsTo(cmd, &compilation.Options{})
+}
 
-	if compilation.IsCompiled() {
-		// by default, we use Namespace == app name
-		options.Namespace = compilation.Name()
+func addTargetOptionsTo(cmd *cobra.Command, opts *compilation.Options) *compilation.TargetOptions {
+	if opts.Target == nil {
+		opts.Target = &compilation.TargetOptions{}
+	}
+	if compilation.IsCompiled() && opts.Target.Namespace == "" {
+		opts.Target.Namespace = compilation.Name()
+	}
+	if opts.Target.Platform == "" {
+		opts.Target.Platform = target.Kubernetes
 	}
 
-	cmd.Flags().VarP(&options.TargetPlatform, "target", "t", "Deployment target [local, kubernetes, ibmcloud, skypilot]")
-	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", options.Namespace, "Kubernetes namespace to deploy to")
+	cmd.Flags().VarP(&opts.Target.Platform, "target", "t", "Deployment target [local, kubernetes, ibmcloud, skypilot]")
+	cmd.Flags().StringVarP(&opts.Target.Namespace, "namespace", "n", opts.Target.Namespace, "Kubernetes namespace to deploy to")
 
-	return &options
+	return opts.Target
 }

--- a/cmd/subcommands/cpu.go
+++ b/cmd/subcommands/cpu.go
@@ -31,7 +31,7 @@ func Newcmd() *cobra.Command {
 			maybeRun = args[0]
 		}
 
-		backend, err := be.New(*tgtOpts, compilation.Options{}) // TODO compilation.Options
+		backend, err := be.New(compilation.Options{Target: tgtOpts})
 		if err != nil {
 			return err
 		}

--- a/cmd/subcommands/down.go
+++ b/cmd/subcommands/down.go
@@ -33,7 +33,7 @@ func newDownCmd() *cobra.Command {
 	tgtOpts := options.AddTargetOptions(cmd)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		backend, err := be.New(*tgtOpts, compilation.Options{ApiKey: apiKey}) // TODO compilation.Options
+		backend, err := be.New(compilation.Options{Target: tgtOpts, ApiKey: apiKey})
 		if err != nil {
 			return err
 		}

--- a/cmd/subcommands/logs.go
+++ b/cmd/subcommands/logs.go
@@ -35,7 +35,7 @@ func newLogsCommand() *cobra.Command {
 	tgtOpts := options.AddTargetOptions(cmd)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		backend, err := be.New(*tgtOpts, compilation.Options{}) // TODO compilation.Options
+		backend, err := be.New(compilation.Options{Target: tgtOpts})
 		if err != nil {
 			return err
 		}

--- a/cmd/subcommands/qcat.go
+++ b/cmd/subcommands/qcat.go
@@ -25,7 +25,7 @@ func newQcatCmd() *cobra.Command {
 	tgtOpts := options.AddTargetOptions(cmd)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		backend, err := be.New(*tgtOpts, compilation.Options{}) // TODO compilation.Options
+		backend, err := be.New(compilation.Options{Target: tgtOpts})
 		if err != nil {
 			return err
 		}

--- a/cmd/subcommands/qin.go
+++ b/cmd/subcommands/qin.go
@@ -27,7 +27,7 @@ func newQcopyinCmd() *cobra.Command {
 	tgtOpts := options.AddTargetOptions(cmd)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		backend, err := be.New(*tgtOpts, compilation.Options{}) // TODO compilation.Options
+		backend, err := be.New(compilation.Options{Target: tgtOpts})
 		if err != nil {
 			return err
 		}

--- a/cmd/subcommands/qlast.go
+++ b/cmd/subcommands/qlast.go
@@ -29,7 +29,7 @@ func newQlastCommand() *cobra.Command {
 			extra = args[1]
 		}
 
-		backend, err := be.New(*tgtOpts, compilation.Options{}) // TODO compilation.Options
+		backend, err := be.New(compilation.Options{Target: tgtOpts})
 		if err != nil {
 			return err
 		}

--- a/cmd/subcommands/qls.go
+++ b/cmd/subcommands/qls.go
@@ -30,7 +30,7 @@ func newQlsCmd() *cobra.Command {
 			path = args[0]
 		}
 
-		backend, err := be.New(*tgtOpts, compilation.Options{}) // TODO compilation.Options
+		backend, err := be.New(compilation.Options{Target: tgtOpts})
 		if err != nil {
 			return err
 		}

--- a/cmd/subcommands/qstat.go
+++ b/cmd/subcommands/qstat.go
@@ -34,7 +34,7 @@ func newQstatCommand() *cobra.Command {
 			maybeRun = args[0]
 		}
 
-		backend, err := be.New(*tgtOpts, compilation.Options{}) // TODO compilation.Options
+		backend, err := be.New(compilation.Options{Target: tgtOpts})
 		if err != nil {
 			return err
 		}

--- a/cmd/subcommands/run/instances.go
+++ b/cmd/subcommands/run/instances.go
@@ -35,7 +35,7 @@ func Instances() *cobra.Command {
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		for {
-			backend, err := be.New(*tgtOpts, compilation.Options{}) // TODO compilation.Options
+			backend, err := be.New(compilation.Options{Target: tgtOpts})
 			if err != nil {
 				if wait {
 					waitItOut(*component, -1, err)

--- a/cmd/subcommands/run/list.go
+++ b/cmd/subcommands/run/list.go
@@ -29,7 +29,7 @@ func List() *cobra.Command {
 	tgtOpts := options.AddTargetOptions(cmd)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		backend, err := be.New(*tgtOpts, compilation.Options{}) // TODO compilation.Options
+		backend, err := be.New(compilation.Options{Target: tgtOpts})
 		if err != nil {
 			return err
 		}

--- a/cmd/subcommands/status.go
+++ b/cmd/subcommands/status.go
@@ -41,7 +41,7 @@ func newStatusCommand() *cobra.Command {
 			maybeRun = args[0]
 		}
 
-		backend, err := be.New(*tgtOpts, compilation.Options{}) // TODO compilation.Options
+		backend, err := be.New(compilation.Options{Target: tgtOpts})
 		if err != nil {
 			return err
 		}

--- a/cmd/subcommands/up.go
+++ b/cmd/subcommands/up.go
@@ -3,43 +3,17 @@
 package subcommands
 
 import (
+	"github.com/spf13/cobra"
+
 	"lunchpail.io/cmd/options"
 	"lunchpail.io/pkg/be"
+	"lunchpail.io/pkg/be/target"
 	"lunchpail.io/pkg/boot"
 	"lunchpail.io/pkg/compilation"
 	"lunchpail.io/pkg/fe/linker"
 	initialize "lunchpail.io/pkg/lunchpail/init"
 	"lunchpail.io/pkg/util"
-
-	"github.com/spf13/cobra"
 )
-
-func addCompilationOptions(cmd *cobra.Command, skipNamespaceFlag bool) *compilation.Options {
-	var options compilation.Options
-
-	if !skipNamespaceFlag {
-		cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "Kubernetes namespace to deploy to")
-	}
-
-	cmd.Flags().StringVarP(&options.ImagePullSecret, "image-pull-secret", "s", "", "Of the form <user>:<token>@ghcr.io")
-	cmd.Flags().StringVarP(&options.Queue, "queue", "", "", "Use the queue defined by this Secret (data: accessKeyID, secretAccessKey, endpoint)")
-	cmd.Flags().BoolVarP(&options.HasGpuSupport, "gpu", "", false, "Run with GPUs (if supported by the application)")
-
-	cmd.Flags().StringSliceVarP(&options.OverrideValues, "set", "", []string{}, "[Advanced] override specific template values")
-	cmd.Flags().StringSliceVarP(&options.OverrideFileValues, "set-file", "", []string{}, "[Advanced] override specific template values with content from a file")
-
-	cmd.Flags().StringVarP(&options.ApiKey, "api-key", "a", "", "IBM Cloud api key")
-	cmd.Flags().StringVarP(&options.ResourceGroupID, "resource-group-id", "", "", "Identifier of a Cloud resource group to contain the instance(s)")
-	//Todo: allow selecting existing ssh key?
-	cmd.Flags().StringVarP(&options.SSHKeyType, "ssh-key-type", "", "rsa", "SSH key type [rsa, ed25519]")
-	cmd.Flags().StringVarP(&options.PublicSSHKey, "public-ssh-key", "", "", "An existing or new SSH public key to identify user on the instance")
-	cmd.Flags().StringVarP(&options.Zone, "zone", "", "", "A location to host the instance")
-	cmd.Flags().StringVarP(&options.Profile, "profile", "", "bx2-8x32", "An instance profile type to choose size and capability of the instance")
-	//TODO: make public image as default
-	cmd.Flags().StringVarP(&options.ImageID, "image-id", "", "", "Identifier of a catalog or custom image to be used for instance creation")
-	cmd.Flags().BoolVarP(&options.CreateNamespace, "create-namespace", "N", false, "Create a new namespace, if needed")
-	return &options
-}
 
 func newUpCmd() *cobra.Command {
 	var verboseFlag bool
@@ -60,36 +34,44 @@ func newUpCmd() *cobra.Command {
 	}
 
 	cmd.Flags().SortFlags = false
-	appOpts := addCompilationOptions(cmd, true)
-	tgtOpts := options.AddTargetOptions(cmd)
+	compilationOpts, err := options.AddCompilationOptions(cmd)
+	if err != nil {
+		panic(err)
+	}
+
 	cmd.Flags().BoolVarP(&dryrunFlag, "dry-run", "", false, "Emit application yaml to stdout")
 	cmd.Flags().BoolVarP(&verboseFlag, "verbose", "v", false, "Verbose output")
 	cmd.Flags().BoolVarP(&watchFlag, "watch", "w", watchFlag, "After deployment, watch for status updates")
 	cmd.Flags().BoolVarP(&createCluster, "create-cluster", "I", false, "Create a new (local) Kubernetes cluster, if needed")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		if tgtOpts.TargetPlatform == be.Kubernetes && createCluster {
+		if compilationOpts.Target.Platform == target.Kubernetes && createCluster {
 			if err := initialize.Local(initialize.InitLocalOptions{BuildImages: false, Verbose: verboseFlag}); err != nil {
 				return err
 			}
 
 			// if we were asked to create a cluster, then certainly we will want to create a namespace
-			appOpts.CreateNamespace = true
+			compilationOpts.CreateNamespace = true
 		}
 
 		overrideValues, err := cmd.Flags().GetStringSlice("set")
 		if err != nil {
 			return err
 		}
+		overrideFileValues, err := cmd.Flags().GetStringSlice("set-file")
+		if err != nil {
+			return err
+		}
 
-		compilationOptions := compilation.Options{Namespace: appOpts.Namespace,
-			ImagePullSecret: appOpts.ImagePullSecret, OverrideValues: overrideValues, Queue: appOpts.Queue,
-			HasGpuSupport: appOpts.HasGpuSupport,
-			ApiKey:        appOpts.ApiKey, ResourceGroupID: appOpts.ResourceGroupID, SSHKeyType: appOpts.SSHKeyType, PublicSSHKey: appOpts.PublicSSHKey,
-			Zone: appOpts.Zone, Profile: appOpts.Profile, ImageID: appOpts.ImageID, CreateNamespace: appOpts.CreateNamespace}
-		configureOptions := linker.ConfigureOptions{CompilationOptions: compilationOptions, Verbose: verboseFlag}
+		// careful: `--set x=3 --set x=4` results in x having
+		// value 4, so we need to place the compiled options
+		// first in the list
+		compilationOpts.OverrideValues = append(compilationOpts.OverrideValues, overrideValues...)
+		compilationOpts.OverrideFileValues = append(compilationOpts.OverrideFileValues, overrideFileValues...)
 
-		backend, err := be.NewInitOk(true, *tgtOpts, compilationOptions)
+		configureOptions := linker.ConfigureOptions{CompilationOptions: *compilationOpts, Verbose: verboseFlag}
+
+		backend, err := be.NewInitOk(true, *compilationOpts)
 		if err != nil {
 			return err
 		}

--- a/pkg/be/new.go
+++ b/pkg/be/new.go
@@ -8,29 +8,25 @@ import (
 	"lunchpail.io/pkg/be/ibmcloud"
 	"lunchpail.io/pkg/be/kubernetes"
 	"lunchpail.io/pkg/be/local"
+	"lunchpail.io/pkg/be/target"
 	"lunchpail.io/pkg/compilation"
 )
 
-type TargetOptions struct {
-	Namespace      string
-	TargetPlatform Platform
-}
-
-func makeIt(topts TargetOptions, aopts compilation.Options) (Backend, error) {
-	switch topts.TargetPlatform {
-	case Local:
+func makeIt(opts compilation.Options) (Backend, error) {
+	switch opts.Target.Platform {
+	case target.Local:
 		return local.New(), nil
-	case Kubernetes:
-		return kubernetes.New(kubernetes.NewOptions{Namespace: topts.Namespace}), nil
-	case IBMCloud:
-		return ibmcloud.New(ibmcloud.NewOptions{Options: aopts, Namespace: topts.Namespace})
+	case target.IBMCloud:
+		return ibmcloud.New(ibmcloud.NewOptions{Options: opts, Namespace: opts.Target.Namespace})
+	case target.Kubernetes:
+		return kubernetes.New(kubernetes.NewOptions{Namespace: opts.Target.Namespace}), nil
 	default:
-		return nil, fmt.Errorf("Unsupported backend %v", topts.TargetPlatform)
+		return nil, fmt.Errorf("Unsupported backend %v", opts.Target.Platform)
 	}
 }
 
-func NewInitOk(initOk bool, topts TargetOptions, aopts compilation.Options) (Backend, error) {
-	be, err := makeIt(topts, aopts)
+func NewInitOk(initOk bool, opts compilation.Options) (Backend, error) {
+	be, err := makeIt(opts)
 	if err != nil {
 		return nil, err
 	}
@@ -42,6 +38,6 @@ func NewInitOk(initOk bool, topts TargetOptions, aopts compilation.Options) (Bac
 	return be, nil
 }
 
-func New(topts TargetOptions, aopts compilation.Options) (Backend, error) {
-	return NewInitOk(false, topts, aopts)
+func New(opts compilation.Options) (Backend, error) {
+	return NewInitOk(false, opts)
 }

--- a/pkg/be/target/platform.go
+++ b/pkg/be/target/platform.go
@@ -1,4 +1,4 @@
-package be
+package target
 
 import "fmt"
 

--- a/pkg/boot/down.go
+++ b/pkg/boot/down.go
@@ -67,7 +67,7 @@ func DownList(runnames []string, backend be.Backend, opts DownOptions) error {
 
 func toCompilationOpts(opts DownOptions) compilation.Options {
 	compilationOptions := compilation.Options{}
-	compilationOptions.Namespace = opts.Namespace
+	compilationOptions.Target = &compilation.TargetOptions{Namespace: opts.Namespace}
 	compilationOptions.ApiKey = opts.ApiKey
 
 	return compilationOptions

--- a/pkg/compilation/compilation.go
+++ b/pkg/compilation/compilation.go
@@ -49,7 +49,7 @@ func IsCompiled() bool {
 	return Name() != "<none>"
 }
 
-func DropBreadcrumb(compilationName, appVersion, stagedir string) error {
+func DropBreadcrumb(compilationName, appVersion string, opts Options, stagedir string) error {
 	user, err := user.Current()
 	if err != nil {
 		return err
@@ -69,6 +69,8 @@ func DropBreadcrumb(compilationName, appVersion, stagedir string) error {
 	} else if err := os.WriteFile(filepath.Join(stagedir, "pkg/compilation/compiledBy.txt"), []byte(fmt.Sprintf("%s <%s>", user.Name, user.Username)), 0644); err != nil {
 		return err
 	} else if err := os.WriteFile(filepath.Join(stagedir, "pkg/compilation/compiledOn.txt"), []byte(hostname), 0644); err != nil {
+		return err
+	} else if err := saveOptions(stagedir, opts); err != nil {
 		return err
 	}
 

--- a/pkg/fe/compiler/compile.go
+++ b/pkg/fe/compiler/compile.go
@@ -62,11 +62,9 @@ func Compile(sourcePath string, opts Options) error {
 
 	if appTemplatePath, appVersion, err := compilation.StagePath(compilationName, sourcePath, compilation.StageOptions{Branch: opts.Branch, Verbose: opts.Verbose}); err != nil {
 		return err
-	} else if err := compilation.SaveOptions(appTemplatePath, opts.CompilationOptions); err != nil {
-		return err
 	} else if err := compilation.MoveAppTemplateIntoLunchpailStage(lunchpailStageDir, appTemplatePath, opts.Verbose); err != nil {
 		return err
-	} else if err := compilation.DropBreadcrumb(compilationName, appVersion, lunchpailStageDir); err != nil {
+	} else if err := compilation.DropBreadcrumb(compilationName, appVersion, opts.CompilationOptions, lunchpailStageDir); err != nil {
 		return err
 	} else {
 		if !opts.AllPlatforms {

--- a/pkg/fe/linker/configure.go
+++ b/pkg/fe/linker/configure.go
@@ -15,7 +15,7 @@ type ConfigureOptions struct {
 	Verbose            bool
 }
 
-func Configure(appname, runname, namespace, templatePath string, internalS3Port int, opts ConfigureOptions) (string, []string, []string, queue.Spec, error) {
+func Configure(appname, runname, templatePath string, internalS3Port int, opts ConfigureOptions) (string, []string, []string, queue.Spec, error) {
 	if opts.Verbose {
 		fmt.Fprintf(os.Stderr, "Stage directory for runname=%s is %s\n", runname, templatePath)
 	}

--- a/pkg/fe/prepare-run.go
+++ b/pkg/fe/prepare-run.go
@@ -20,58 +20,12 @@ type CompileOptions struct {
 	UseThisRunName string
 }
 
-// TODO move into RestoreOptions
-func valuesFromShrinkwrap(templatePath string, opts compilation.Options) (llir.Options, error) {
-	shrinkwrappedOptions, err := compilation.RestoreOptions(templatePath)
-	if err != nil {
-		return opts, err
-	} else {
-		if opts.Namespace == "" {
-			opts.Namespace = shrinkwrappedOptions.Namespace
-		}
-		// TODO here... how do we determine that boolean values were unset?
-		if opts.ImagePullSecret == "" {
-			opts.ImagePullSecret = shrinkwrappedOptions.ImagePullSecret
-		}
-
-		// careful: `--set x=3 --set x=4` results in x having
-		// value 4, so we need to place the shrinkwrapped
-		// options first in the list
-		opts.OverrideValues = append(shrinkwrappedOptions.OverrideValues, opts.OverrideValues...)
-		opts.OverrideFileValues = append(shrinkwrappedOptions.OverrideFileValues, opts.OverrideFileValues...)
-
-		if opts.Queue == "" {
-			opts.Queue = shrinkwrappedOptions.Queue
-		}
-		// TODO here... how do we determine that boolean values were unset?
-		if opts.HasGpuSupport == false {
-			opts.HasGpuSupport = shrinkwrappedOptions.HasGpuSupport
-		}
-		if !opts.CreateNamespace {
-			opts.CreateNamespace = shrinkwrappedOptions.CreateNamespace
-		}
-	}
-
-	return opts, nil
-}
-
 func PrepareForRun(opts CompileOptions) (llir.LLIR, compilation.Options, error) {
 	stageOpts := compilation.StageOptions{}
 	stageOpts.Verbose = opts.Verbose
 	compilationName, templatePath, _, err := compilation.Stage(stageOpts)
 	if err != nil {
 		return llir.LLIR{}, opts.CompilationOptions, err
-	}
-
-	if updatedOpts, err := valuesFromShrinkwrap(templatePath, opts.CompilationOptions); err != nil {
-		return llir.LLIR{}, opts.CompilationOptions, err
-	} else {
-		opts.CompilationOptions = updatedOpts
-	}
-
-	namespace := opts.CompilationOptions.Namespace
-	if namespace == "" {
-		namespace = compilationName
 	}
 
 	runname := opts.UseThisRunName
@@ -88,7 +42,7 @@ func PrepareForRun(opts CompileOptions) (llir.LLIR, compilation.Options, error) 
 		fmt.Fprintf(os.Stderr, "Using internal S3 port %d\n", internalS3Port)
 	}
 
-	yamlValues, dashdashSetValues, dashdashSetFileValues, queueSpec, err := linker.Configure(compilationName, runname, namespace, templatePath, internalS3Port, opts.ConfigureOptions)
+	yamlValues, dashdashSetValues, dashdashSetFileValues, queueSpec, err := linker.Configure(compilationName, runname, templatePath, internalS3Port, opts.ConfigureOptions)
 	if err != nil {
 		return llir.LLIR{}, opts.CompilationOptions, err
 	}
@@ -98,6 +52,7 @@ func PrepareForRun(opts CompileOptions) (llir.LLIR, compilation.Options, error) 
 	}
 
 	// we need to instantiate the application's templates first...
+	namespace := "" // intentionally not passing Target.Namespace to application templates
 	if yaml, err := helm.Template(runname, namespace, templatePath, yamlValues, helm.TemplateOptions{OverrideValues: dashdashSetValues, OverrideFileValues: dashdashSetFileValues, Verbose: opts.Verbose}); err != nil {
 		return llir.LLIR{}, opts.CompilationOptions, err
 	} else if hlir, err := parser.Parse(yaml); err != nil {

--- a/pkg/observe/info/model.go
+++ b/pkg/observe/info/model.go
@@ -13,12 +13,7 @@ type Info struct {
 }
 
 func Model() (Info, error) {
-	_, templatePath, _, err := compilation.Stage(compilation.StageOptions{})
-	if err != nil {
-		return Info{}, err
-	}
-
-	shrinkwrappedOptions, err := compilation.RestoreOptions(templatePath)
+	shrinkwrappedOptions, err := compilation.RestoreOptions()
 	if err != nil {
 		return Info{}, err
 	}

--- a/pkg/observe/info/ui.go
+++ b/pkg/observe/info/ui.go
@@ -13,7 +13,7 @@ func UI() error {
 		return err
 	}
 
-	bold := colors.Bold.Faint(true)
+	bold := colors.Bold
 
 	fmt.Printf("%-24s %s\n", bold.Render("Name"), colors.Cyan.Render(info.Name))
 	fmt.Printf("%-24s %s\n", bold.Render("Created By"), info.By)
@@ -26,11 +26,11 @@ func UI() error {
 	}
 
 	optsString := strings.TrimSpace(string(optsBytes))
-	fmt.Printf("\n%s\n", bold.Render("Shrinkwrapped Values"))
+	fmt.Printf("\n%s\n", bold.Render("Values"))
 	if optsString == "{}" {
 		optsString = "none"
 	}
-	fmt.Println(colors.Yellow.Render(optsString))
+	fmt.Println(optsString)
 
 	return nil
 }

--- a/tests/bin/add-data.sh
+++ b/tests/bin/add-data.sh
@@ -8,7 +8,7 @@
 set -eo pipefail
 
 # Wait for minio component
-echo "$(tput setaf 2)Pre-Populating s3 bucket $bucket from $bucket_path (waiting for s3 to be ready)$(tput sgr0)"
+echo "$(tput setaf 2)Pre-Populating s3 app=$testapp target=${LUNCHPAIL_TARGET:-kubernetes} (waiting for s3 to be ready)$(tput sgr0)"
 $testapp run instances \
          --namespace $NAMESPACE \
          --target ${LUNCHPAIL_TARGET:-kubernetes} \
@@ -18,7 +18,7 @@ $testapp run instances \
 for bucket_path in $@; do
     if [[ -d $bucket_path ]]; then
         bucket=$(basename $bucket_path)
-        echo "$(tput setaf 2)Populating s3 bucket $bucket from $bucket_path$(tput sgr0)"
+        echo "$(tput setaf 2)Populating s3 app=$testapp target=${LUNCHPAIL_TARGET:-kubernetes} bucket=$bucket from $bucket_path$(tput sgr0)"
         $testapp qin $bucket_path $bucket --target ${LUNCHPAIL_TARGET:-kubernetes}
     fi
 done


### PR DESCRIPTION
- cleans up the TargetOptions, consolidating the Namespace flag from compilation.Options into compilation.Target.Namespace, and adding compilation.Target.Platform that was previously a be-specific option, via be.TargetOptions
- cleans up the cmd/ logic to consolidate adding target options and adding compilation options
- save/restore compilationOptions.json via embed
- fixes for overrideValues and overrideFileValues
- test coverage currently in compile.sh compileTimeTarget