### PR TITLE
fix: pass through context to streamer APIs

### DIFF
--- a/cmd/subcommands/cpu.go
+++ b/cmd/subcommands/cpu.go
@@ -3,6 +3,7 @@
 package subcommands
 
 import (
+	"context"
 	"github.com/spf13/cobra"
 
 	"lunchpail.io/cmd/options"
@@ -36,7 +37,7 @@ func Newcmd() *cobra.Command {
 			return err
 		}
 
-		return cpu.UI(maybeRun, backend, cpu.CpuOptions{Namespace: tgtOpts.Namespace, Verbose: verboseFlag, IntervalSeconds: intervalSecondsFlag})
+		return cpu.UI(context.Background(), maybeRun, backend, cpu.CpuOptions{Namespace: tgtOpts.Namespace, Verbose: verboseFlag, IntervalSeconds: intervalSecondsFlag})
 	}
 
 	return cmd

--- a/cmd/subcommands/down.go
+++ b/cmd/subcommands/down.go
@@ -3,6 +3,7 @@
 package subcommands
 
 import (
+	"context"
 	"github.com/spf13/cobra"
 
 	"lunchpail.io/cmd/options"
@@ -38,7 +39,7 @@ func newDownCmd() *cobra.Command {
 			return err
 		}
 
-		return boot.DownList(args, backend, boot.DownOptions{
+		return boot.DownList(context.Background(), args, backend, boot.DownOptions{
 			Namespace: tgtOpts.Namespace, Verbose: verboseFlag, DeleteNamespace: deleteNamespaceFlag,
 			DeleteAll: deleteAllRunsFlag,
 			ApiKey:    apiKey, DeleteCloudResources: deleteCloudResourcesFlag})

--- a/cmd/subcommands/logs.go
+++ b/cmd/subcommands/logs.go
@@ -3,6 +3,7 @@
 package subcommands
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -58,7 +59,7 @@ func newLogsCommand() *cobra.Command {
 			}
 		}
 
-		return observe.Logs(runOpts.Run, backend, observe.LogsOptions{Follow: followFlag, Tail: tailFlag, Verbose: verboseFlag, Components: comps})
+		return observe.Logs(context.Background(), runOpts.Run, backend, observe.LogsOptions{Follow: followFlag, Tail: tailFlag, Verbose: verboseFlag, Components: comps})
 	}
 
 	return cmd

--- a/cmd/subcommands/qlast.go
+++ b/cmd/subcommands/qlast.go
@@ -3,6 +3,7 @@
 package subcommands
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -34,7 +35,7 @@ func newQlastCommand() *cobra.Command {
 			return err
 		}
 
-		val, err := qstat.Qlast(marker, extra, backend, qstat.QlastOptions{})
+		val, err := qstat.Qlast(context.Background(), marker, extra, backend, qstat.QlastOptions{})
 		if err != nil {
 			return err
 		}

--- a/cmd/subcommands/qstat.go
+++ b/cmd/subcommands/qstat.go
@@ -3,6 +3,7 @@
 package subcommands
 
 import (
+	"context"
 	"github.com/spf13/cobra"
 
 	"lunchpail.io/cmd/options"
@@ -39,7 +40,7 @@ func newQstatCommand() *cobra.Command {
 			return err
 		}
 
-		return qstat.UI(maybeRun, backend, qstat.Options{Follow: followFlag, Tail: tailFlag, Verbose: verboseFlag, Quiet: quietFlag})
+		return qstat.UI(context.Background(), maybeRun, backend, qstat.Options{Follow: followFlag, Tail: tailFlag, Verbose: verboseFlag, Quiet: quietFlag})
 	}
 
 	return cmd

--- a/cmd/subcommands/status.go
+++ b/cmd/subcommands/status.go
@@ -3,6 +3,7 @@
 package subcommands
 
 import (
+	"context"
 	"github.com/spf13/cobra"
 
 	"lunchpail.io/cmd/options"
@@ -46,7 +47,7 @@ func newStatusCommand() *cobra.Command {
 			return err
 		}
 
-		return status.UI(maybeRun, backend, status.Options{Watch: watchFlag, Verbose: verboseFlag, Summary: summaryFlag, Nloglines: loglinesFlag, IntervalSeconds: intervalFlag})
+		return status.UI(context.Background(), maybeRun, backend, status.Options{Watch: watchFlag, Verbose: verboseFlag, Summary: summaryFlag, Nloglines: loglinesFlag, IntervalSeconds: intervalFlag})
 	}
 
 	return cmd

--- a/cmd/subcommands/up.go
+++ b/cmd/subcommands/up.go
@@ -3,6 +3,7 @@
 package subcommands
 
 import (
+	"context"
 	"github.com/spf13/cobra"
 
 	"lunchpail.io/cmd/options"
@@ -76,7 +77,7 @@ func newUpCmd() *cobra.Command {
 			return err
 		}
 
-		return boot.Up(backend, boot.UpOptions{ConfigureOptions: configureOptions, DryRun: dryrunFlag, Watch: watchFlag})
+		return boot.Up(context.Background(), backend, boot.UpOptions{ConfigureOptions: configureOptions, DryRun: dryrunFlag, Watch: watchFlag})
 	}
 
 	return cmd

--- a/pkg/be/backend.go
+++ b/pkg/be/backend.go
@@ -38,5 +38,5 @@ type Backend interface {
 	AccessQueue(ctx context.Context, runname string) (endpoint, accessKeyID, secretAccessKey, bucket, prefixPath string, stop func(), err error)
 
 	// Return a streamer
-	Streamer() streamer.Streamer
+	Streamer(ctx context.Context, runname string) streamer.Streamer
 }

--- a/pkg/be/ibmcloud/logs.go
+++ b/pkg/be/ibmcloud/logs.go
@@ -7,6 +7,6 @@ import (
 )
 
 // Stream logs from a given Component to the given channel
-func (streamer Streamer) ComponentLogs(runname string, component lunchpail.Component, tail int, follow, verbose bool) error {
+func (streamer Streamer) ComponentLogs(component lunchpail.Component, tail int, follow, verbose bool) error {
 	return fmt.Errorf("Unsupported operation: 'ComponentLogs'")
 }

--- a/pkg/be/ibmcloud/qstat.go
+++ b/pkg/be/ibmcloud/qstat.go
@@ -3,11 +3,9 @@ package ibmcloud
 import (
 	"fmt"
 
-	"golang.org/x/sync/errgroup"
-
 	"lunchpail.io/pkg/be/events/qstat"
 )
 
-func (streamer Streamer) QueueStats(runname string, opts qstat.Options) (chan qstat.Model, *errgroup.Group, error) {
-	return nil, nil, fmt.Errorf("Unsupported operation: 'StreamQueueStats'")
+func (streamer Streamer) QueueStats(opts qstat.Options) (chan qstat.Model, error) {
+	return nil, fmt.Errorf("Unsupported operation: 'StreamQueueStats'")
 }

--- a/pkg/be/ibmcloud/streamer.go
+++ b/pkg/be/ibmcloud/streamer.go
@@ -1,12 +1,18 @@
 package ibmcloud
 
-import "lunchpail.io/pkg/be/streamer"
+import (
+	"context"
+
+	"lunchpail.io/pkg/be/streamer"
+)
 
 type Streamer struct {
+	context.Context
+	runname string
 	backend Backend
 }
 
 // Return a streamer
-func (backend Backend) Streamer() streamer.Streamer {
-	return Streamer{backend}
+func (backend Backend) Streamer(ctx context.Context, runname string) streamer.Streamer {
+	return Streamer{ctx, runname, backend}
 }

--- a/pkg/be/ibmcloud/updates.go
+++ b/pkg/be/ibmcloud/updates.go
@@ -6,10 +6,10 @@ import (
 	"lunchpail.io/pkg/be/events"
 )
 
-func (streamer Streamer) RunEvents(runname string) (chan events.Message, error) {
+func (streamer Streamer) RunEvents() (chan events.Message, error) {
 	return nil, fmt.Errorf("Unsupported operation: StreamRunEvents")
 }
 
-func (streamer Streamer) RunComponentUpdates(runname string) (chan events.ComponentUpdate, chan events.Message, error) {
+func (streamer Streamer) RunComponentUpdates() (chan events.ComponentUpdate, chan events.Message, error) {
 	return nil, nil, fmt.Errorf("Unsupported operation: StreamRunComponentUpdates")
 }

--- a/pkg/be/ibmcloud/utilization.go
+++ b/pkg/be/ibmcloud/utilization.go
@@ -7,6 +7,6 @@ import (
 )
 
 // Stream cpu and memory statistics
-func (streamer Streamer) Utilization(runname string, intervalSeconds int) (chan utilization.Model, error) {
+func (streamer Streamer) Utilization(intervalSeconds int) (chan utilization.Model, error) {
 	return nil, fmt.Errorf("Unsupported operation: 'StreamUtilization'")
 }

--- a/pkg/be/kubernetes/events.go
+++ b/pkg/be/kubernetes/events.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"context"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
@@ -26,14 +25,14 @@ func stream(runname string, watcher watch.Interface, c chan events.Message) {
 	}
 }
 
-func (streamer Streamer) RunEvents(runname string) (chan events.Message, error) {
+func (streamer Streamer) RunEvents() (chan events.Message, error) {
 	clientset, _, err := Client()
 	if err != nil {
 		return nil, err
 	}
 
 	timeout := timeoutSeconds
-	eventWatcher, err := clientset.CoreV1().Events(streamer.backend.namespace).Watch(context.Background(), metav1.ListOptions{
+	eventWatcher, err := clientset.CoreV1().Events(streamer.backend.namespace).Watch(streamer.Context, metav1.ListOptions{
 		TimeoutSeconds: &timeout,
 	})
 	if err != nil {
@@ -41,7 +40,7 @@ func (streamer Streamer) RunEvents(runname string) (chan events.Message, error) 
 	}
 
 	c := make(chan events.Message)
-	go stream(runname, eventWatcher, c)
+	go stream(streamer.runname, eventWatcher, c)
 
 	return c, nil
 }

--- a/pkg/be/kubernetes/streamer.go
+++ b/pkg/be/kubernetes/streamer.go
@@ -1,12 +1,18 @@
 package kubernetes
 
-import "lunchpail.io/pkg/be/streamer"
+import (
+	"context"
+
+	"lunchpail.io/pkg/be/streamer"
+)
 
 type Streamer struct {
+	context.Context
+	runname string
 	backend Backend
 }
 
 // Return a streamer
-func (backend Backend) Streamer() streamer.Streamer {
-	return Streamer{backend}
+func (backend Backend) Streamer(ctx context.Context, runname string) streamer.Streamer {
+	return Streamer{ctx, runname, backend}
 }

--- a/pkg/be/kubernetes/updates.go
+++ b/pkg/be/kubernetes/updates.go
@@ -91,7 +91,7 @@ func (streamer Streamer) updateFromPod(pod *v1.Pod, what watch.EventType, cc cha
 	case string(lunchpail.WorkersComponent):
 		if what == watch.Added {
 			// new worker pod. start streaming its logs
-			if err := streamLogUpdatesForWorker(pod.Name, pod.Namespace, cm); err != nil {
+			if err := streamLogUpdatesForWorker(streamer.Context, pod.Name, pod.Namespace, cm); err != nil {
 				return err
 			} else {
 				// TODO: are we leaking something
@@ -135,8 +135,8 @@ func (streamer Streamer) streamPodUpdates(watcher watch.Interface, cc chan event
 	}
 }
 
-func (streamer Streamer) RunComponentUpdates(runname string) (chan events.ComponentUpdate, chan events.Message, error) {
-	watcher, err := startWatching(runname, streamer.backend.namespace)
+func (streamer Streamer) RunComponentUpdates() (chan events.ComponentUpdate, chan events.Message, error) {
+	watcher, err := startWatching(streamer.runname, streamer.backend.namespace)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/be/streamer/streamer.go
+++ b/pkg/be/streamer/streamer.go
@@ -1,8 +1,6 @@
 package streamer
 
 import (
-	"golang.org/x/sync/errgroup"
-
 	"lunchpail.io/pkg/be/events"
 	"lunchpail.io/pkg/be/events/qstat"
 	"lunchpail.io/pkg/be/events/utilization"
@@ -11,17 +9,17 @@ import (
 
 type Streamer interface {
 	//
-	RunEvents(runname string) (chan events.Message, error)
+	RunEvents() (chan events.Message, error)
 
 	//
-	RunComponentUpdates(runname string) (chan events.ComponentUpdate, chan events.Message, error)
+	RunComponentUpdates() (chan events.ComponentUpdate, chan events.Message, error)
 
 	// Stream cpu and memory statistics
-	Utilization(runname string, intervalSeconds int) (chan utilization.Model, error)
+	Utilization(intervalSeconds int) (chan utilization.Model, error)
 
 	// Stream queue statistics
-	QueueStats(runname string, opts qstat.Options) (chan qstat.Model, *errgroup.Group, error)
+	QueueStats(opts qstat.Options) (chan qstat.Model, error)
 
 	// Stream logs from a given Component to os.Stdout
-	ComponentLogs(runname string, component lunchpail.Component, tail int, follow, verbose bool) error
+	ComponentLogs(component lunchpail.Component, tail int, follow, verbose bool) error
 }

--- a/pkg/boot/up.go
+++ b/pkg/boot/up.go
@@ -3,6 +3,7 @@
 package boot
 
 import (
+	"context"
 	"fmt"
 
 	"lunchpail.io/pkg/be"
@@ -12,7 +13,7 @@ import (
 
 type UpOptions = fe.CompileOptions
 
-func upDown(backend be.Backend, opts UpOptions, isUp bool) error {
+func upDown(ctx context.Context, backend be.Backend, opts UpOptions, isUp bool) error {
 	ir, copts, err := fe.PrepareForRun(opts)
 	if err != nil {
 		return err
@@ -25,7 +26,7 @@ func upDown(backend be.Backend, opts UpOptions, isUp bool) error {
 		if err := backend.Up(ir, copts, opts.Verbose); err != nil {
 			return err
 		} else if opts.Watch {
-			return status.UI(ir.RunName, backend, status.Options{Watch: true, Verbose: opts.Verbose, Summary: false, Nloglines: 500, IntervalSeconds: 5})
+			return status.UI(ctx, ir.RunName, backend, status.Options{Watch: true, Verbose: opts.Verbose, Summary: false, Nloglines: 500, IntervalSeconds: 5})
 		}
 	} else if err := backend.Down(ir, copts, opts.Verbose); err != nil {
 		return err
@@ -34,8 +35,8 @@ func upDown(backend be.Backend, opts UpOptions, isUp bool) error {
 	return nil
 }
 
-func Up(backend be.Backend, opts UpOptions) error {
-	if err := upDown(backend, opts, true); err != nil {
+func Up(ctx context.Context, backend be.Backend, opts UpOptions) error {
+	if err := upDown(ctx, backend, opts, true); err != nil {
 		return err
 	}
 

--- a/pkg/observe/cpu/ui.go
+++ b/pkg/observe/cpu/ui.go
@@ -1,6 +1,7 @@
 package cpu
 
 import (
+	"context"
 	"fmt"
 
 	"lunchpail.io/pkg/be"
@@ -14,13 +15,13 @@ type CpuOptions struct {
 	IntervalSeconds int
 }
 
-func UI(runnameIn string, backend be.Backend, opts CpuOptions) error {
+func UI(ctx context.Context, runnameIn string, backend be.Backend, opts CpuOptions) error {
 	runname, err := util.WaitForRun(runnameIn, true, backend)
 	if err != nil {
 		return err
 	}
 
-	c, err := backend.Streamer().Utilization(runname, opts.IntervalSeconds)
+	c, err := backend.Streamer(ctx, runname).Utilization(opts.IntervalSeconds)
 	if err != nil {
 		return err
 	}

--- a/pkg/observe/qstat/qlast.go
+++ b/pkg/observe/qstat/qlast.go
@@ -1,6 +1,7 @@
 package qstat
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -13,13 +14,13 @@ import (
 type QlastOptions struct {
 }
 
-func Qlast(marker, opt string, backend be.Backend, opts QlastOptions) (string, error) {
+func Qlast(ctx context.Context, marker, opt string, backend be.Backend, opts QlastOptions) (string, error) {
 	runname, err := util.WaitForRun("", true, backend)
 	if err != nil {
 		return "", err
 	}
 
-	c, _, err := backend.Streamer().QueueStats(runname, qstat.Options{Tail: int64(1000)})
+	c, err := backend.Streamer(ctx, runname).QueueStats(qstat.Options{Tail: int64(1000)})
 	if err != nil {
 		return strconv.Itoa(0), err
 	}

--- a/pkg/observe/qstat/ui.go
+++ b/pkg/observe/qstat/ui.go
@@ -1,6 +1,7 @@
 package qstat
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strconv"
@@ -16,13 +17,13 @@ import (
 
 type Options = qstat.Options
 
-func UI(runnameIn string, backend be.Backend, opts Options) error {
+func UI(ctx context.Context, runnameIn string, backend be.Backend, opts Options) error {
 	runname, err := util.WaitForRun(runnameIn, true, backend)
 	if err != nil {
 		return err
 	}
 
-	c, errs, err := backend.Streamer().QueueStats(runname, opts)
+	c, err := backend.Streamer(ctx, runname).QueueStats(opts)
 	if err != nil {
 		return err
 	}
@@ -77,5 +78,5 @@ func UI(runnameIn string, backend be.Backend, opts Options) error {
 		fmt.Println(t)
 	}
 
-	return errs.Wait()
+	return nil
 }

--- a/pkg/observe/status/ui.go
+++ b/pkg/observe/status/ui.go
@@ -1,6 +1,7 @@
 package status
 
 import (
+	"context"
 	"os"
 	"slices"
 	"strings"
@@ -131,7 +132,7 @@ func (m model) View() string {
 	return strings.Join(lines, "\n")
 }
 
-func UI(runnameIn string, backend be.Backend, opts Options) error {
+func UI(ctx context.Context, runnameIn string, backend be.Backend, opts Options) error {
 	runname, err := util.WaitForRun(runnameIn, opts.Watch, backend)
 	if err != nil {
 		return err
@@ -145,7 +146,7 @@ func UI(runnameIn string, backend be.Backend, opts Options) error {
 		defer f.Close()
 	}
 
-	c, _, err := StatusStreamer(runname, backend, opts.Verbose, opts.Nloglines, opts.IntervalSeconds)
+	c, err := StatusStreamer(ctx, runname, backend, opts.Verbose, opts.Nloglines, opts.IntervalSeconds)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The goal is to avoid closed channels by wrapping everything in a context tree.

This also updates the Streamer API to move the common bits (runname and, now, context) to the constructor and away from the instance methods.