### PR TITLE
fix: backend.Ok() should accept a context

### DIFF
--- a/cmd/subcommands/cpu.go
+++ b/cmd/subcommands/cpu.go
@@ -32,12 +32,13 @@ func Newcmd() *cobra.Command {
 			maybeRun = args[0]
 		}
 
-		backend, err := be.New(compilation.Options{Target: tgtOpts})
+		ctx := context.Background()
+		backend, err := be.New(ctx, compilation.Options{Target: tgtOpts})
 		if err != nil {
 			return err
 		}
 
-		return cpu.UI(context.Background(), maybeRun, backend, cpu.CpuOptions{Namespace: tgtOpts.Namespace, Verbose: verboseFlag, IntervalSeconds: intervalSecondsFlag})
+		return cpu.UI(ctx, maybeRun, backend, cpu.CpuOptions{Namespace: tgtOpts.Namespace, Verbose: verboseFlag, IntervalSeconds: intervalSecondsFlag})
 	}
 
 	return cmd

--- a/cmd/subcommands/down.go
+++ b/cmd/subcommands/down.go
@@ -34,12 +34,13 @@ func newDownCmd() *cobra.Command {
 	tgtOpts := options.AddTargetOptions(cmd)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		backend, err := be.New(compilation.Options{Target: tgtOpts, ApiKey: apiKey})
+		ctx := context.Background()
+		backend, err := be.New(ctx, compilation.Options{Target: tgtOpts, ApiKey: apiKey})
 		if err != nil {
 			return err
 		}
 
-		return boot.DownList(context.Background(), args, backend, boot.DownOptions{
+		return boot.DownList(ctx, args, backend, boot.DownOptions{
 			Namespace: tgtOpts.Namespace, Verbose: verboseFlag, DeleteNamespace: deleteNamespaceFlag,
 			DeleteAll: deleteAllRunsFlag,
 			ApiKey:    apiKey, DeleteCloudResources: deleteCloudResourcesFlag})

--- a/cmd/subcommands/init/local.go
+++ b/cmd/subcommands/init/local.go
@@ -1,7 +1,10 @@
 package init
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
+
 	initialize "lunchpail.io/pkg/lunchpail/init"
 )
 
@@ -14,7 +17,7 @@ func NewInitLocalCmd() *cobra.Command {
 		Short: "Initialize a local control plane",
 		Long:  "Initialize a local control plane",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return initialize.Local(initialize.InitLocalOptions{BuildImages: buildFlag, Verbose: verboseFlag})
+			return initialize.Local(context.Background(), initialize.InitLocalOptions{BuildImages: buildFlag, Verbose: verboseFlag})
 		},
 	}
 

--- a/cmd/subcommands/logs.go
+++ b/cmd/subcommands/logs.go
@@ -36,7 +36,8 @@ func newLogsCommand() *cobra.Command {
 	tgtOpts := options.AddTargetOptions(cmd)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		backend, err := be.New(compilation.Options{Target: tgtOpts})
+		ctx := context.Background()
+		backend, err := be.New(ctx, compilation.Options{Target: tgtOpts})
 		if err != nil {
 			return err
 		}
@@ -59,7 +60,7 @@ func newLogsCommand() *cobra.Command {
 			}
 		}
 
-		return observe.Logs(context.Background(), runOpts.Run, backend, observe.LogsOptions{Follow: followFlag, Tail: tailFlag, Verbose: verboseFlag, Components: comps})
+		return observe.Logs(ctx, runOpts.Run, backend, observe.LogsOptions{Follow: followFlag, Tail: tailFlag, Verbose: verboseFlag, Components: comps})
 	}
 
 	return cmd

--- a/cmd/subcommands/qcat.go
+++ b/cmd/subcommands/qcat.go
@@ -25,12 +25,13 @@ func newQcatCmd() *cobra.Command {
 	tgtOpts := options.AddTargetOptions(cmd)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		backend, err := be.New(compilation.Options{Target: tgtOpts})
+		ctx := context.Background()
+		backend, err := be.New(ctx, compilation.Options{Target: tgtOpts})
 		if err != nil {
 			return err
 		}
 
-		return queue.Qcat(context.Background(), backend, runOpts.Run, args[0])
+		return queue.Qcat(ctx, backend, runOpts.Run, args[0])
 	}
 
 	return cmd

--- a/cmd/subcommands/qin.go
+++ b/cmd/subcommands/qin.go
@@ -27,12 +27,13 @@ func newQcopyinCmd() *cobra.Command {
 	tgtOpts := options.AddTargetOptions(cmd)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		backend, err := be.New(compilation.Options{Target: tgtOpts})
+		ctx := context.Background()
+		backend, err := be.New(ctx, compilation.Options{Target: tgtOpts})
 		if err != nil {
 			return err
 		}
 
-		return queue.CopyIn(context.Background(), backend, runname, args[0], args[1])
+		return queue.CopyIn(ctx, backend, runname, args[0], args[1])
 	}
 
 	return cmd

--- a/cmd/subcommands/qlast.go
+++ b/cmd/subcommands/qlast.go
@@ -30,12 +30,13 @@ func newQlastCommand() *cobra.Command {
 			extra = args[1]
 		}
 
-		backend, err := be.New(compilation.Options{Target: tgtOpts})
+		ctx := context.Background()
+		backend, err := be.New(ctx, compilation.Options{Target: tgtOpts})
 		if err != nil {
 			return err
 		}
 
-		val, err := qstat.Qlast(context.Background(), marker, extra, backend, qstat.QlastOptions{})
+		val, err := qstat.Qlast(ctx, marker, extra, backend, qstat.QlastOptions{})
 		if err != nil {
 			return err
 		}

--- a/cmd/subcommands/qls.go
+++ b/cmd/subcommands/qls.go
@@ -30,12 +30,13 @@ func newQlsCmd() *cobra.Command {
 			path = args[0]
 		}
 
-		backend, err := be.New(compilation.Options{Target: tgtOpts})
+		ctx := context.Background()
+		backend, err := be.New(ctx, compilation.Options{Target: tgtOpts})
 		if err != nil {
 			return err
 		}
 
-		return queue.Qls(context.Background(), backend, runOpts.Run, path)
+		return queue.Qls(ctx, backend, runOpts.Run, path)
 	}
 
 	return cmd

--- a/cmd/subcommands/qstat.go
+++ b/cmd/subcommands/qstat.go
@@ -35,12 +35,13 @@ func newQstatCommand() *cobra.Command {
 			maybeRun = args[0]
 		}
 
-		backend, err := be.New(compilation.Options{Target: tgtOpts})
+		ctx := context.Background()
+		backend, err := be.New(ctx, compilation.Options{Target: tgtOpts})
 		if err != nil {
 			return err
 		}
 
-		return qstat.UI(context.Background(), maybeRun, backend, qstat.Options{Follow: followFlag, Tail: tailFlag, Verbose: verboseFlag, Quiet: quietFlag})
+		return qstat.UI(ctx, maybeRun, backend, qstat.Options{Follow: followFlag, Tail: tailFlag, Verbose: verboseFlag, Quiet: quietFlag})
 	}
 
 	return cmd

--- a/cmd/subcommands/run/instances.go
+++ b/cmd/subcommands/run/instances.go
@@ -35,8 +35,9 @@ func Instances() *cobra.Command {
 	cmd.MarkFlagRequired("component")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		ctx := context.Background()
 		for {
-			backend, err := be.New(compilation.Options{Target: tgtOpts})
+			backend, err := be.New(ctx, compilation.Options{Target: tgtOpts})
 			if err != nil {
 				if wait {
 					waitItOut(*component, -1, err)

--- a/cmd/subcommands/run/list.go
+++ b/cmd/subcommands/run/list.go
@@ -30,12 +30,13 @@ func List() *cobra.Command {
 	tgtOpts := options.AddTargetOptions(cmd)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		backend, err := be.New(compilation.Options{Target: tgtOpts})
+		ctx := context.Background()
+		backend, err := be.New(ctx, compilation.Options{Target: tgtOpts})
 		if err != nil {
 			return err
 		}
 
-		runs, err := backend.ListRuns(context.Background(), all)
+		runs, err := backend.ListRuns(ctx, all)
 		if err != nil {
 			return err
 		}

--- a/cmd/subcommands/status.go
+++ b/cmd/subcommands/status.go
@@ -42,12 +42,13 @@ func newStatusCommand() *cobra.Command {
 			maybeRun = args[0]
 		}
 
-		backend, err := be.New(compilation.Options{Target: tgtOpts})
+		ctx := context.Background()
+		backend, err := be.New(ctx, compilation.Options{Target: tgtOpts})
 		if err != nil {
 			return err
 		}
 
-		return status.UI(context.Background(), maybeRun, backend, status.Options{Watch: watchFlag, Verbose: verboseFlag, Summary: summaryFlag, Nloglines: loglinesFlag, IntervalSeconds: intervalFlag})
+		return status.UI(ctx, maybeRun, backend, status.Options{Watch: watchFlag, Verbose: verboseFlag, Summary: summaryFlag, Nloglines: loglinesFlag, IntervalSeconds: intervalFlag})
 	}
 
 	return cmd

--- a/pkg/be/backend.go
+++ b/pkg/be/backend.go
@@ -11,7 +11,7 @@ import (
 
 type Backend interface {
 	// Is the backend ready for `up`?
-	Ok(initOk bool) error
+	Ok(ctx context.Context, initOk bool) error
 
 	// Bring up the linked application
 	Up(ctx context.Context, linked llir.LLIR, opts llir.Options, verbose bool) error

--- a/pkg/be/ibmcloud/ok.go
+++ b/pkg/be/ibmcloud/ok.go
@@ -1,10 +1,14 @@
 package ibmcloud
 
-import "github.com/IBM/vpc-go-sdk/vpcv1"
+import (
+	"context"
+
+	"github.com/IBM/vpc-go-sdk/vpcv1"
+)
 
 // Validate that our vpc service works
 // TODO: this should accept no arguments and be a method on an instance that we return
-func (backend Backend) Ok(initOk bool) error {
+func (backend Backend) Ok(ctx context.Context, initOk bool) error {
 	limit := int64(1)
 	resourceGroupId := backend.config.ResourceGroup.GUID
 

--- a/pkg/be/kubernetes/ok.go
+++ b/pkg/be/kubernetes/ok.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"time"
@@ -11,10 +12,10 @@ import (
 	initialize "lunchpail.io/pkg/lunchpail/init"
 )
 
-func (backend Backend) Ok(initOk bool) error {
+func (backend Backend) Ok(ctx context.Context, initOk bool) error {
 	announcedWait := false
 	for {
-		if err := backend.ok(initOk); err != nil {
+		if err := backend.ok(ctx, initOk); err != nil {
 			if !initOk && clientcmd.IsEmptyConfig(err) {
 				if !announcedWait {
 					announcedWait = true
@@ -33,12 +34,12 @@ func (backend Backend) Ok(initOk bool) error {
 	return nil
 }
 
-func (backend Backend) ok(initOk bool) error {
+func (backend Backend) ok(ctx context.Context, initOk bool) error {
 	_, config, err := Client()
 	if err != nil {
 		if clientcmd.IsEmptyConfig(err) && initOk {
 			if ok, buildImages := userIsOkWithInit(); ok {
-				return initialize.Local(initialize.InitLocalOptions{BuildImages: buildImages})
+				return initialize.Local(ctx, initialize.InitLocalOptions{BuildImages: buildImages})
 			}
 			return err
 		}

--- a/pkg/be/local/ok.go
+++ b/pkg/be/local/ok.go
@@ -1,6 +1,7 @@
 package local
 
 import (
+	"context"
 	"fmt"
 
 	"lunchpail.io/pkg/be/local/shell"
@@ -8,7 +9,7 @@ import (
 )
 
 // Is the backend ready for `up`?
-func (backend Backend) Ok(initOk bool) error {
+func (backend Backend) Ok(ctx context.Context, initOk bool) error {
 	return nil
 }
 

--- a/pkg/be/new.go
+++ b/pkg/be/new.go
@@ -3,6 +3,7 @@
 package be
 
 import (
+	"context"
 	"fmt"
 
 	"lunchpail.io/pkg/be/ibmcloud"
@@ -25,19 +26,19 @@ func makeIt(opts compilation.Options) (Backend, error) {
 	}
 }
 
-func NewInitOk(initOk bool, opts compilation.Options) (Backend, error) {
+func NewInitOk(ctx context.Context, initOk bool, opts compilation.Options) (Backend, error) {
 	be, err := makeIt(opts)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := be.Ok(initOk); err != nil {
+	if err := be.Ok(ctx, initOk); err != nil {
 		return nil, err
 	}
 
 	return be, nil
 }
 
-func New(opts compilation.Options) (Backend, error) {
-	return NewInitOk(false, opts)
+func New(ctx context.Context, opts compilation.Options) (Backend, error) {
+	return NewInitOk(ctx, false, opts)
 }

--- a/pkg/lunchpail/init/local.go
+++ b/pkg/lunchpail/init/local.go
@@ -12,8 +12,8 @@ type InitLocalOptions struct {
 	Verbose     bool
 }
 
-func Local(opts InitLocalOptions) error {
-	errs, _ := errgroup.WithContext(context.Background())
+func Local(ctx context.Context, opts InitLocalOptions) error {
+	errs, _ := errgroup.WithContext(ctx)
 
 	if err := getContainerCli(); err != nil {
 		return err

--- a/tests/bin/up.sh
+++ b/tests/bin/up.sh
@@ -25,6 +25,7 @@ $testapp up \
          $APP \
          $GPU \
          $LP_ARGS \
+         --create-cluster \
          --target=${LUNCHPAIL_TARGET:-kubernetes} \
          --watch=false \
          --set global.arch=$ARCH \


### PR DESCRIPTION
This also adjusts the behavior of `up` so that it only creates a cluster if the user passes `--create-cluster`. Unfortunately, create-cluster is not currently a compile-time flag, but still this seems the safer option for now.