### PR TITLE
fix: removing verbose as parameter and use compilationOptions

### DIFF
--- a/cmd/subcommands/worker/run.go
+++ b/cmd/subcommands/worker/run.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"lunchpail.io/cmd/options"
 	"lunchpail.io/pkg/runtime/worker"
 )
 
@@ -17,15 +18,14 @@ func NewRunCmd() *cobra.Command {
 		Args:  cobra.MatchAll(cobra.OnlyValidArgs),
 	}
 
-	var debug bool
-	cmd.Flags().BoolVarP(&debug, "debug", "g", false, "Run in debug mode, which will emit extra log information")
+	logOpts := options.AddLogOptions(cmd)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
 			return fmt.Errorf("Nothing to run. Specify the worker command line after a --: %v", args)
 		}
 
-		return worker.Run(context.Background(), args, worker.Options{Debug: debug})
+		return worker.Run(context.Background(), args, worker.Options{Debug: logOpts.Debug})
 	}
 
 	return cmd

--- a/pkg/be/backend.go
+++ b/pkg/be/backend.go
@@ -14,13 +14,13 @@ type Backend interface {
 	Ok(ctx context.Context, initOk bool) error
 
 	// Bring up the linked application
-	Up(ctx context.Context, linked llir.LLIR, opts llir.Options, verbose bool) error
+	Up(ctx context.Context, linked llir.LLIR, opts llir.Options) error
 
 	// Bring down the linked application
-	Down(ctx context.Context, linked llir.LLIR, opts llir.Options, verbose bool) error
+	Down(ctx context.Context, linked llir.LLIR, opts llir.Options) error
 
 	// Return a string to convey relevant dry-run info
-	DryRun(ir llir.LLIR, opts llir.Options, verbose bool) (string, error)
+	DryRun(ir llir.LLIR, opts llir.Options) (string, error)
 
 	// Purge any non-run resources that may have been created
 	Purge(ctx context.Context) error

--- a/pkg/be/ibmcloud/down.go
+++ b/pkg/be/ibmcloud/down.go
@@ -6,8 +6,8 @@ import (
 	"lunchpail.io/pkg/ir/llir"
 )
 
-func (backend Backend) Down(ctx context.Context, ir llir.LLIR, opts llir.Options, verbose bool) error {
-	if err := backend.SetAction(ctx, opts, ir, Delete, verbose); err != nil {
+func (backend Backend) Down(ctx context.Context, ir llir.LLIR, opts llir.Options) error {
+	if err := backend.SetAction(ctx, opts, ir, Delete); err != nil {
 		return err
 	}
 

--- a/pkg/be/ibmcloud/dryrun.go
+++ b/pkg/be/ibmcloud/dryrun.go
@@ -6,6 +6,6 @@ import (
 	"lunchpail.io/pkg/ir/llir"
 )
 
-func (backend Backend) DryRun(ir llir.LLIR, opts llir.Options, verbose bool) (string, error) {
+func (backend Backend) DryRun(ir llir.LLIR, opts llir.Options) (string, error) {
 	return "", fmt.Errorf("Unsupported operation: 'DryRun'")
 }

--- a/pkg/be/ibmcloud/up.go
+++ b/pkg/be/ibmcloud/up.go
@@ -6,8 +6,8 @@ import (
 	"lunchpail.io/pkg/ir/llir"
 )
 
-func (backend Backend) Up(ctx context.Context, ir llir.LLIR, opts llir.Options, verbose bool) error {
-	if err := backend.SetAction(ctx, opts, ir, Create, verbose); err != nil {
+func (backend Backend) Up(ctx context.Context, ir llir.LLIR, opts llir.Options) error {
+	if err := backend.SetAction(ctx, opts, ir, Create); err != nil {
 		return err
 	}
 

--- a/pkg/be/kubernetes/apply.go
+++ b/pkg/be/kubernetes/apply.go
@@ -62,13 +62,13 @@ func apply(ctx context.Context, yaml, namespace, context string, operation Opera
 	return cmd.Run()
 }
 
-func applyOperation(ctx context.Context, ir llir.LLIR, namespace, context string, operation Operation, copts llir.Options, verbose bool) error {
+func applyOperation(ctx context.Context, ir llir.LLIR, namespace, context string, operation Operation, copts llir.Options) error {
 	opts, err := k8sOptions(ctx, copts)
 	if err != nil {
 		return err
 	}
 
-	yamls, err := MarshalAllComponents(ir, namespace, opts, verbose)
+	yamls, err := MarshalAllComponents(ir, namespace, opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/be/kubernetes/common/marshal.go
+++ b/pkg/be/kubernetes/common/marshal.go
@@ -2,14 +2,14 @@ package common
 
 import "lunchpail.io/pkg/ir/llir"
 
-func MarshalCommonResources(ir llir.LLIR, namespace string, opts Options, verbose bool) ([]string, error) {
+func MarshalCommonResources(ir llir.LLIR, namespace string, opts Options) ([]string, error) {
 	yamls := []string{}
 
 	if len(ir.AppProvidedKubernetesResources) > 0 {
 		yamls = append(yamls, ir.AppProvidedKubernetesResources)
 	}
 
-	if yaml, err := templateLunchpailCommonResources(ir, namespace, opts, verbose); err != nil {
+	if yaml, err := templateLunchpailCommonResources(ir, namespace, opts); err != nil {
 		return []string{}, err
 	} else {
 		yamls = append(yamls, yaml)

--- a/pkg/be/kubernetes/common/template.go
+++ b/pkg/be/kubernetes/common/template.go
@@ -11,11 +11,11 @@ import (
 	"lunchpail.io/pkg/util"
 )
 
-func templateLunchpailCommonResources(ir llir.LLIR, namespace string, opts Options, verbose bool) (string, error) {
+func templateLunchpailCommonResources(ir llir.LLIR, namespace string, opts Options) (string, error) {
 	templatePath, err := stage(appTemplate, appTemplateFile)
 	if err != nil {
 		return "", err
-	} else if verbose {
+	} else if opts.Log.Verbose {
 		fmt.Fprintf(os.Stderr, "Templating Kubernetes common components to %s\n", templatePath)
 	} else {
 		defer os.RemoveAll(templatePath)
@@ -31,7 +31,7 @@ func templateLunchpailCommonResources(ir llir.LLIR, namespace string, opts Optio
 		namespace,
 		templatePath,
 		"", // no yaml values at the moment
-		helm.TemplateOptions{Verbose: verbose, OverrideValues: values},
+		helm.TemplateOptions{Verbose: opts.Log.Verbose, OverrideValues: values},
 	)
 }
 

--- a/pkg/be/kubernetes/common/values.go
+++ b/pkg/be/kubernetes/common/values.go
@@ -36,5 +36,6 @@ func Values(ir llir.LLIR, opts Options) ([]string, error) {
 		"lunchpail.image.registry=" + lunchpail.ImageRegistry,
 		"lunchpail.image.repo=" + lunchpail.ImageRepo,
 		"lunchpail.image.version=" + lunchpail.Version(),
+		fmt.Sprintf("lunchpail.debug=%v", opts.Log.Debug),
 	}, nil
 }

--- a/pkg/be/kubernetes/down.go
+++ b/pkg/be/kubernetes/down.go
@@ -6,8 +6,8 @@ import (
 	"lunchpail.io/pkg/ir/llir"
 )
 
-func (backend Backend) Down(ctx context.Context, ir llir.LLIR, opts llir.Options, verbose bool) error {
-	if err := applyOperation(ctx, ir, backend.namespace, "", DeleteIt, opts, verbose); err != nil {
+func (backend Backend) Down(ctx context.Context, ir llir.LLIR, opts llir.Options) error {
+	if err := applyOperation(ctx, ir, backend.namespace, "", DeleteIt, opts); err != nil {
 		return err
 	}
 

--- a/pkg/be/kubernetes/marshal.go
+++ b/pkg/be/kubernetes/marshal.go
@@ -10,10 +10,10 @@ import (
 )
 
 // Marshal one component.
-func marshalComponent(ir llir.LLIR, c llir.Component, namespace string, opts common.Options, verbose bool) (string, error) {
+func marshalComponent(ir llir.LLIR, c llir.Component, namespace string, opts common.Options) (string, error) {
 	switch cc := c.(type) {
 	case llir.ShellComponent:
-		return shell.Template(ir, cc, namespace, opts, verbose)
+		return shell.Template(ir, cc, namespace, opts)
 	}
 
 	return "", fmt.Errorf("Unsupported component type")
@@ -21,14 +21,14 @@ func marshalComponent(ir llir.LLIR, c llir.Component, namespace string, opts com
 
 // Marshal all components, including the common resources needed to
 // make them function in a cluster.
-func MarshalAllComponents(ir llir.LLIR, namespace string, opts common.Options, verbose bool) ([]string, error) {
-	yamls, err := common.MarshalCommonResources(ir, namespace, opts, verbose)
+func MarshalAllComponents(ir llir.LLIR, namespace string, opts common.Options) ([]string, error) {
+	yamls, err := common.MarshalCommonResources(ir, namespace, opts)
 	if err != nil {
 		return []string{}, err
 	}
 
 	for _, c := range ir.Components {
-		yaml, err := marshalComponent(ir, c, namespace, opts, verbose)
+		yaml, err := marshalComponent(ir, c, namespace, opts)
 		if err != nil {
 			return []string{}, err
 		}
@@ -41,9 +41,9 @@ func MarshalAllComponents(ir llir.LLIR, namespace string, opts common.Options, v
 
 // This is to present a single string form of all of the yaml,
 // e.g. for dry-running.
-func (backend Backend) DryRun(ir llir.LLIR, copts llir.Options, verbose bool) (string, error) {
+func (backend Backend) DryRun(ir llir.LLIR, copts llir.Options) (string, error) {
 	opts := common.Options{Options: copts}
-	if arr, err := MarshalAllComponents(ir, backend.namespace, opts, verbose); err != nil {
+	if arr, err := MarshalAllComponents(ir, backend.namespace, opts); err != nil {
 		return "", err
 	} else {
 		return util.Join(arr), nil
@@ -52,15 +52,15 @@ func (backend Backend) DryRun(ir llir.LLIR, copts llir.Options, verbose bool) (s
 
 // marshal resources for this component, including common resources
 // needed to make it function on its own in a cluster.
-func MarshalComponentAsStandalone(ir llir.LLIR, c llir.Component, namespace string, opts common.Options, verbose bool) (string, error) {
-	yamls, err := common.MarshalCommonResources(ir, namespace, opts, verbose)
+func MarshalComponentAsStandalone(ir llir.LLIR, c llir.Component, namespace string, opts common.Options) (string, error) {
+	yamls, err := common.MarshalCommonResources(ir, namespace, opts)
 	if err != nil {
 		return "", err
 	}
 
 	// yamls = append(yamls, c.Config)
 
-	yaml, err := marshalComponent(ir, c, namespace, opts, verbose)
+	yaml, err := marshalComponent(ir, c, namespace, opts)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/be/kubernetes/shell/template.go
+++ b/pkg/be/kubernetes/shell/template.go
@@ -13,11 +13,11 @@ import (
 	"lunchpail.io/pkg/util"
 )
 
-func Template(ir llir.LLIR, c llir.ShellComponent, namespace string, opts common.Options, verbose bool) (string, error) {
+func Template(ir llir.LLIR, c llir.ShellComponent, namespace string, opts common.Options) (string, error) {
 	templatePath, err := stage(template, templateFile)
 	if err != nil {
 		return "", err
-	} else if verbose {
+	} else if opts.Log.Verbose {
 		fmt.Fprintf(os.Stderr, "Shell stage %s\n", templatePath)
 	} else {
 		defer os.RemoveAll(templatePath)
@@ -56,7 +56,6 @@ func Template(ir llir.LLIR, c llir.ShellComponent, namespace string, opts common
 		"image=" + c.Application.Spec.Image,
 		"command=" + updateTestQueueEndpoint(c.Application.Spec.Command, ir.Queue),
 		fmt.Sprintf("lunchpail.runAsJob=%v", c.RunAsJob),
-		// fmt.Sprintf("lunchpail.debug=%v", verbose),
 		"lunchpail.terminationGracePeriodSeconds=" + strconv.Itoa(terminationGracePeriodSeconds),
 		"workers.count=" + strconv.Itoa(c.Sizing.Workers),
 		"workers.cpu=" + c.Sizing.Cpu,
@@ -97,7 +96,7 @@ func Template(ir llir.LLIR, c llir.ShellComponent, namespace string, opts common
 
 	values := slices.Concat(commonValues, myValues)
 
-	if verbose {
+	if opts.Log.Verbose {
 		workdirCmData := ""
 		fmt.Fprintf(os.Stderr, "Shell values\n%s\n", strings.Replace(strings.Join(values, "\n  - "), workdirCmData, "", 1))
 	}
@@ -107,6 +106,6 @@ func Template(ir llir.LLIR, c llir.ShellComponent, namespace string, opts common
 		namespace,
 		templatePath,
 		"", // no yaml values at the moment
-		helm.TemplateOptions{Verbose: verbose, OverrideValues: values},
+		helm.TemplateOptions{Verbose: opts.Log.Verbose, OverrideValues: values},
 	)
 }

--- a/pkg/be/kubernetes/up.go
+++ b/pkg/be/kubernetes/up.go
@@ -8,10 +8,10 @@ import (
 	"lunchpail.io/pkg/util"
 )
 
-func (backend Backend) Up(ctx context.Context, ir llir.LLIR, opts llir.Options, verbose bool) error {
+func (backend Backend) Up(ctx context.Context, ir llir.LLIR, opts llir.Options) error {
 	ir.Queue = ir.Queue.UpdateEndpoint(fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", util.Dns1035(ir.RunName+"-minio"), backend.namespace, ir.Queue.Port))
 
-	if err := applyOperation(ctx, ir, backend.namespace, "", ApplyIt, opts, verbose); err != nil {
+	if err := applyOperation(ctx, ir, backend.namespace, "", ApplyIt, opts); err != nil {
 		return err
 	}
 

--- a/pkg/be/local/down.go
+++ b/pkg/be/local/down.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Bring down the linked application
-func (backend Backend) Down(ctx context.Context, ir llir.LLIR, opts llir.Options, verbose bool) error {
+func (backend Backend) Down(ctx context.Context, ir llir.LLIR, opts llir.Options) error {
 	if err := backend.IsCompatible(ir); err != nil {
 		return err
 	}

--- a/pkg/be/local/dryrun.go
+++ b/pkg/be/local/dryrun.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Return a string to convey relevant dry-run info
-func (backend Backend) DryRun(ir llir.LLIR, opts llir.Options, verbose bool) (string, error) {
+func (backend Backend) DryRun(ir llir.LLIR, opts llir.Options) (string, error) {
 	if err := backend.IsCompatible(ir); err != nil {
 		return "", err
 	}

--- a/pkg/be/local/up.go
+++ b/pkg/be/local/up.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Bring up the linked application
-func (backend Backend) Up(octx context.Context, ir llir.LLIR, opts llir.Options, verbose bool) error {
+func (backend Backend) Up(octx context.Context, ir llir.LLIR, opts llir.Options) error {
 	if err := backend.IsCompatible(ir); err != nil {
 		return err
 	}

--- a/pkg/boot/down.go
+++ b/pkg/boot/down.go
@@ -76,7 +76,7 @@ func toCompilationOpts(opts DownOptions) compilation.Options {
 func toUpOpts(runname string, opts DownOptions) UpOptions {
 	configureOptions := linker.ConfigureOptions{}
 	configureOptions.CompilationOptions = toCompilationOpts(opts)
-	configureOptions.Verbose = opts.Verbose
+	configureOptions.CompilationOptions.Log.Verbose = opts.Verbose
 
 	upOptions := UpOptions{}
 	upOptions.ConfigureOptions = configureOptions

--- a/pkg/boot/up.go
+++ b/pkg/boot/up.go
@@ -29,15 +29,15 @@ func upDown(ctx context.Context, backend be.Backend, opts UpOptions, isUp bool) 
 	}
 
 	if opts.DryRun {
-		fmt.Printf(backend.DryRun(ir, copts, opts.Verbose))
+		fmt.Printf(backend.DryRun(ir, copts))
 		return nil
 	} else if isUp {
-		if err := backend.Up(ctx, ir, copts, opts.Verbose); err != nil {
+		if err := backend.Up(ctx, ir, copts); err != nil {
 			return err
 		} else if opts.Watch {
-			return status.UI(ctx, ir.RunName, backend, status.Options{Watch: true, Verbose: opts.Verbose, Summary: false, Nloglines: 500, IntervalSeconds: 5})
+			return status.UI(ctx, ir.RunName, backend, status.Options{Watch: true, Verbose: opts.CompilationOptions.Log.Verbose, Summary: false, Nloglines: 500, IntervalSeconds: 5})
 		}
-	} else if err := backend.Down(ctx, ir, copts, opts.Verbose); err != nil {
+	} else if err := backend.Down(ctx, ir, copts); err != nil {
 		return err
 	}
 

--- a/pkg/fe/linker/configure.go
+++ b/pkg/fe/linker/configure.go
@@ -12,11 +12,10 @@ import (
 
 type ConfigureOptions struct {
 	CompilationOptions compilation.Options
-	Verbose            bool
 }
 
 func Configure(appname, runname, templatePath string, internalS3Port int, opts ConfigureOptions) (string, []string, []string, queue.Spec, error) {
-	if opts.Verbose {
+	if opts.CompilationOptions.Log.Verbose {
 		fmt.Fprintf(os.Stderr, "Stage directory for runname=%s is %s\n", runname, templatePath)
 	}
 
@@ -63,7 +62,7 @@ lunchpail:
 		appname,                 // (16)
 	)
 
-	if opts.Verbose {
+	if opts.CompilationOptions.Log.Verbose {
 		fmt.Fprintf(os.Stderr, "shrinkwrap app values=%s\n", yaml)
 		fmt.Fprintf(os.Stderr, "shrinkwrap app overrides=%v\n", opts.CompilationOptions.OverrideValues)
 		fmt.Fprintf(os.Stderr, "shrinkwrap app file overrides=%v\n", opts.CompilationOptions.OverrideFileValues)

--- a/pkg/fe/transformer/api/dispatch/lower.go
+++ b/pkg/fe/transformer/api/dispatch/lower.go
@@ -9,11 +9,11 @@ import (
 )
 
 // HLIR -> LLIR for []hlir.ParameterSweep, ...
-func Lower(compilationName, runname string, model hlir.AppModel, ir llir.LLIR, opts compilation.Options, verbose bool) ([]llir.Component, error) {
+func Lower(compilationName, runname string, model hlir.AppModel, ir llir.LLIR, opts compilation.Options) ([]llir.Component, error) {
 	components := []llir.Component{}
 
 	for _, r := range model.ParameterSweeps {
-		if component, err := parametersweep.Lower(compilationName, runname, r, ir, opts, verbose); err != nil {
+		if component, err := parametersweep.Lower(compilationName, runname, r, ir, opts); err != nil {
 			return components, err
 		} else {
 			components = append(components, component)
@@ -21,7 +21,7 @@ func Lower(compilationName, runname string, model hlir.AppModel, ir llir.LLIR, o
 	}
 
 	for _, r := range model.ProcessS3Objects {
-		if component, err := s3.Lower(compilationName, runname, r, ir, opts, verbose); err != nil {
+		if component, err := s3.Lower(compilationName, runname, r, ir, opts); err != nil {
 			return components, err
 		} else {
 			components = append(components, component)

--- a/pkg/fe/transformer/api/dispatch/parametersweep/lower.go
+++ b/pkg/fe/transformer/api/dispatch/parametersweep/lower.go
@@ -8,7 +8,7 @@ import (
 	"lunchpail.io/pkg/lunchpail"
 )
 
-func Lower(compilationName, runname string, sweep hlir.ParameterSweep, ir llir.LLIR, opts compilation.Options, verbose bool) (llir.Component, error) {
+func Lower(compilationName, runname string, sweep hlir.ParameterSweep, ir llir.LLIR, opts compilation.Options) (llir.Component, error) {
 	app, err := transpile(sweep)
 	if err != nil {
 		return nil, err
@@ -21,6 +21,5 @@ func Lower(compilationName, runname string, sweep hlir.ParameterSweep, ir llir.L
 		ir,
 		llir.ShellComponent{Component: lunchpail.DispatcherComponent},
 		opts,
-		verbose,
 	)
 }

--- a/pkg/fe/transformer/api/dispatch/s3/lower.go
+++ b/pkg/fe/transformer/api/dispatch/s3/lower.go
@@ -8,7 +8,7 @@ import (
 	"lunchpail.io/pkg/lunchpail"
 )
 
-func Lower(compilationName, runname string, s3 hlir.ProcessS3Objects, ir llir.LLIR, opts compilation.Options, verbose bool) (llir.Component, error) {
+func Lower(compilationName, runname string, s3 hlir.ProcessS3Objects, ir llir.LLIR, opts compilation.Options) (llir.Component, error) {
 	app, err := transpile(s3)
 	if err != nil {
 		return nil, err
@@ -21,6 +21,5 @@ func Lower(compilationName, runname string, s3 hlir.ProcessS3Objects, ir llir.LL
 		ir,
 		llir.ShellComponent{Component: lunchpail.DispatcherComponent},
 		opts,
-		verbose,
 	)
 }

--- a/pkg/fe/transformer/api/minio/lower.go
+++ b/pkg/fe/transformer/api/minio/lower.go
@@ -8,7 +8,7 @@ import (
 	"lunchpail.io/pkg/lunchpail"
 )
 
-func Lower(compilationName, runname string, model hlir.AppModel, ir llir.LLIR, opts compilation.Options, verbose bool) (llir.Component, error) {
+func Lower(compilationName, runname string, model hlir.AppModel, ir llir.LLIR, opts compilation.Options) (llir.Component, error) {
 	if !ir.Queue.Auto {
 		return nil, nil
 	}
@@ -25,7 +25,6 @@ func Lower(compilationName, runname string, model hlir.AppModel, ir llir.LLIR, o
 		ir,
 		llir.ShellComponent{Component: lunchpail.MinioComponent},
 		opts,
-		verbose,
 	)
 
 	return component, err

--- a/pkg/fe/transformer/api/shell/lower.go
+++ b/pkg/fe/transformer/api/shell/lower.go
@@ -12,7 +12,7 @@ import (
 	"lunchpail.io/pkg/lunchpail"
 )
 
-func Lower(compilationName, runname string, app hlir.Application, ir llir.LLIR, opts compilation.Options, verbose bool) (llir.Component, error) {
+func Lower(compilationName, runname string, app hlir.Application, ir llir.LLIR, opts compilation.Options) (llir.Component, error) {
 	var component lunchpail.Component
 	switch app.Spec.Role {
 	case "worker":
@@ -21,10 +21,10 @@ func Lower(compilationName, runname string, app hlir.Application, ir llir.LLIR, 
 		component = lunchpail.DispatcherComponent
 	}
 
-	return LowerAsComponent(compilationName, runname, app, ir, llir.ShellComponent{Component: component}, opts, verbose)
+	return LowerAsComponent(compilationName, runname, app, ir, llir.ShellComponent{Component: component}, opts)
 }
 
-func LowerAsComponent(compilationName, runname string, app hlir.Application, ir llir.LLIR, component llir.ShellComponent, opts compilation.Options, verbose bool) (llir.Component, error) {
+func LowerAsComponent(compilationName, runname string, app hlir.Application, ir llir.LLIR, component llir.ShellComponent, opts compilation.Options) (llir.Component, error) {
 	component.Application = app
 	if component.Sizing.Workers == 0 {
 		component.Sizing = api.ApplicationSizing(app, opts)

--- a/pkg/fe/transformer/api/workerpool/lower.go
+++ b/pkg/fe/transformer/api/workerpool/lower.go
@@ -12,7 +12,7 @@ import (
 	"lunchpail.io/pkg/lunchpail"
 )
 
-func Lower(compilationName, runname string, app hlir.Application, pool hlir.WorkerPool, ir llir.LLIR, opts compilation.Options, verbose bool) (llir.Component, error) {
+func Lower(compilationName, runname string, app hlir.Application, pool hlir.WorkerPool, ir llir.LLIR, opts compilation.Options) (llir.Component, error) {
 	spec := llir.ShellComponent{Component: lunchpail.WorkersComponent}
 
 	spec.RunAsJob = true
@@ -29,11 +29,8 @@ func Lower(compilationName, runname string, app hlir.Application, pool hlir.Work
 	}
 	app.Spec.Env["LUNCHPAIL_STARTUP_DELAY"] = strconv.Itoa(startupDelay)
 
-	// for now, we don't distinguish the two...
-	debug := verbose
-
 	app.Spec.Command = fmt.Sprintf(`trap "$LUNCHPAIL_EXE worker prestop" EXIT
-$LUNCHPAIL_EXE worker run --debug=%v -- %s`, debug, app.Spec.Command)
+$LUNCHPAIL_EXE worker run --debug=%v -- %s`, opts.Log.Debug, app.Spec.Command)
 
 	return shell.LowerAsComponent(
 		compilationName,
@@ -42,6 +39,5 @@ $LUNCHPAIL_EXE worker run --debug=%v -- %s`, debug, app.Spec.Command)
 		ir,
 		spec,
 		opts,
-		verbose,
 	)
 }

--- a/pkg/fe/transformer/api/workerpool/lowerall.go
+++ b/pkg/fe/transformer/api/workerpool/lowerall.go
@@ -9,7 +9,7 @@ import (
 )
 
 // HLIR -> LLIR for []hlir.WorkerPool
-func LowerAll(compilationName, runname string, model hlir.AppModel, ir llir.LLIR, opts compilation.Options, verbose bool) ([]llir.Component, error) {
+func LowerAll(compilationName, runname string, model hlir.AppModel, ir llir.LLIR, opts compilation.Options) ([]llir.Component, error) {
 	components := []llir.Component{}
 
 	app, found := model.GetApplicationByRole(hlir.WorkerRole)
@@ -18,7 +18,7 @@ func LowerAll(compilationName, runname string, model hlir.AppModel, ir llir.LLIR
 	}
 
 	for _, pool := range model.WorkerPools {
-		if component, err := Lower(compilationName, runname, app, pool, ir, opts, verbose); err != nil {
+		if component, err := Lower(compilationName, runname, app, pool, ir, opts); err != nil {
 			return components, err
 		} else {
 			components = append(components, component)

--- a/pkg/fe/transformer/api/workstealer/lower.go
+++ b/pkg/fe/transformer/api/workstealer/lower.go
@@ -7,7 +7,7 @@ import (
 	"lunchpail.io/pkg/lunchpail"
 )
 
-func Lower(compilationName, runname string, ir llir.LLIR, opts compilation.Options, verbose bool) (llir.Component, error) {
+func Lower(compilationName, runname string, ir llir.LLIR, opts compilation.Options) (llir.Component, error) {
 	app, err := transpile(runname)
 	if err != nil {
 		return nil, err
@@ -20,6 +20,5 @@ func Lower(compilationName, runname string, ir llir.LLIR, opts compilation.Optio
 		ir,
 		llir.ShellComponent{Component: lunchpail.WorkStealerComponent},
 		opts,
-		verbose,
 	)
 }

--- a/pkg/fe/transformer/application.go
+++ b/pkg/fe/transformer/application.go
@@ -9,14 +9,14 @@ import (
 )
 
 // HLIR -> LLIR for []hlir.Application
-func lowerApplications(compilationName, runname string, model hlir.AppModel, ir llir.LLIR, opts compilation.Options, verbose bool) ([]llir.Component, error) {
+func lowerApplications(compilationName, runname string, model hlir.AppModel, ir llir.LLIR, opts compilation.Options) ([]llir.Component, error) {
 	components := []llir.Component{}
 
 	if workstealer.IsNeeded(model) {
 		// Note, the actual worker resources will be dealt
 		// with when a WorkerPool is created. Here, we only
 		// need to specify a WorkStealer.
-		c, err := workstealer.Lower(compilationName, runname, ir, opts, verbose)
+		c, err := workstealer.Lower(compilationName, runname, ir, opts)
 		if err != nil {
 			return nil, err
 		}
@@ -26,7 +26,7 @@ func lowerApplications(compilationName, runname string, model hlir.AppModel, ir 
 	// Then, for every non-Worker, we lower it as a "shell"
 	for _, app := range model.Applications {
 		if app.Spec.Role != hlir.WorkerRole {
-			c, err := shell.Lower(compilationName, runname, app, ir, opts, verbose)
+			c, err := shell.Lower(compilationName, runname, app, ir, opts)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/fe/transformer/lower.go
+++ b/pkg/fe/transformer/lower.go
@@ -13,10 +13,10 @@ import (
 )
 
 // HLIR -> LLIR
-func Lower(compilationName, runname string, model hlir.AppModel, queueSpec queue.Spec, opts compilation.Options, verbose bool) (llir.LLIR, error) {
+func Lower(compilationName, runname string, model hlir.AppModel, queueSpec queue.Spec, opts compilation.Options) (llir.LLIR, error) {
 	ir := llir.LLIR{AppName: compilationName, RunName: runname, Queue: queueSpec}
 
-	minio, err := minio.Lower(compilationName, runname, model, ir, opts, verbose)
+	minio, err := minio.Lower(compilationName, runname, model, ir, opts)
 	if err != nil {
 		return llir.LLIR{}, err
 	}
@@ -24,17 +24,17 @@ func Lower(compilationName, runname string, model hlir.AppModel, queueSpec queue
 		ir.Components = slices.Concat([]llir.Component{minio})
 	}
 
-	apps, err := lowerApplications(compilationName, runname, model, ir, opts, verbose)
+	apps, err := lowerApplications(compilationName, runname, model, ir, opts)
 	if err != nil {
 		return llir.LLIR{}, err
 	}
 
-	dispatchers, err := dispatch.Lower(compilationName, runname, model, ir, opts, verbose)
+	dispatchers, err := dispatch.Lower(compilationName, runname, model, ir, opts)
 	if err != nil {
 		return llir.LLIR{}, err
 	}
 
-	pools, err := workerpool.LowerAll(compilationName, runname, model, ir, opts, verbose)
+	pools, err := workerpool.LowerAll(compilationName, runname, model, ir, opts)
 	if err != nil {
 		return llir.LLIR{}, err
 	}


### PR DESCRIPTION
Second PR of the log verbose/debug setup set of PRs... (first one #276)

Cleaning up `verbose bool` as parameter in many places, and use directly from compilationOptions