### PR TITLE
fix: removing verbose as parameter and use compilationOptions cont..

### DIFF
--- a/cmd/subcommands/compile.go
+++ b/cmd/subcommands/compile.go
@@ -60,7 +60,6 @@ func newCompileCmd() *cobra.Command {
 		return compiler.Compile(context.Background(), sourcePath, compiler.Options{
 			Name:               outputFlag,
 			Branch:             branchFlag,
-			Verbose:            compilationOptions.Log.Verbose,
 			AllPlatforms:       allFlag,
 			CompilationOptions: *compilationOptions,
 		})

--- a/pkg/be/kubernetes/common/template.go
+++ b/pkg/be/kubernetes/common/template.go
@@ -13,9 +13,10 @@ import (
 
 func templateLunchpailCommonResources(ir llir.LLIR, namespace string, opts Options) (string, error) {
 	templatePath, err := stage(appTemplate, appTemplateFile)
+	verbose := opts.Log.Verbose
 	if err != nil {
 		return "", err
-	} else if opts.Log.Verbose {
+	} else if verbose {
 		fmt.Fprintf(os.Stderr, "Templating Kubernetes common components to %s\n", templatePath)
 	} else {
 		defer os.RemoveAll(templatePath)
@@ -31,7 +32,7 @@ func templateLunchpailCommonResources(ir llir.LLIR, namespace string, opts Optio
 		namespace,
 		templatePath,
 		"", // no yaml values at the moment
-		helm.TemplateOptions{Verbose: opts.Log.Verbose, OverrideValues: values},
+		helm.TemplateOptions{Verbose: verbose, OverrideValues: values},
 	)
 }
 

--- a/pkg/fe/compiler/compile.go
+++ b/pkg/fe/compiler/compile.go
@@ -37,9 +37,10 @@ func Compile(ctx context.Context, sourcePath string, opts Options) error {
 	}
 
 	lunchpailStageDir, err := stageLunchpailItself()
+	verbose := opts.CompilationOptions.Log.Verbose
 	if err != nil {
 		return err
-	} else if opts.Verbose {
+	} else if verbose {
 		fmt.Fprintf(os.Stderr, "Stage directory: %s\n", lunchpailStageDir)
 	}
 
@@ -56,13 +57,13 @@ func Compile(ctx context.Context, sourcePath string, opts Options) error {
 		}
 	}
 
-	if opts.Verbose {
+	if verbose {
 		fmt.Fprintf(os.Stderr, "Using compilationName=%s\n", compilationName)
 	}
 
-	if appTemplatePath, appVersion, err := compilation.StagePath(compilationName, sourcePath, compilation.StageOptions{Branch: opts.Branch, Verbose: opts.Verbose}); err != nil {
+	if appTemplatePath, appVersion, err := compilation.StagePath(compilationName, sourcePath, compilation.StageOptions{Branch: opts.Branch, Verbose: verbose}); err != nil {
 		return err
-	} else if err := compilation.MoveAppTemplateIntoLunchpailStage(lunchpailStageDir, appTemplatePath, opts.Verbose); err != nil {
+	} else if err := compilation.MoveAppTemplateIntoLunchpailStage(lunchpailStageDir, appTemplatePath, verbose); err != nil {
 		return err
 	} else if err := compilation.DropBreadcrumb(compilationName, appVersion, opts.CompilationOptions, lunchpailStageDir); err != nil {
 		return err

--- a/pkg/fe/compiler/options.go
+++ b/pkg/fe/compiler/options.go
@@ -5,7 +5,6 @@ import "lunchpail.io/pkg/compilation"
 type Options struct {
 	Name               string
 	Branch             string
-	Verbose            bool
 	AllPlatforms       bool
 	CompilationOptions compilation.Options
 }

--- a/tests/tests/test7-wait/pail/dispatcher.yaml
+++ b/tests/tests/test7-wait/pail/dispatcher.yaml
@@ -9,3 +9,4 @@ spec:
   interval: {{ .Values.every | default 5 }}
   wait: true
   verbose: true
+  debug: true


### PR DESCRIPTION
Third PR of the log verbose/debug setup set of PRs... (first one https://github.com/IBM/lunchpail/pull/276, second one #277 )

Cleaning up verbose bool as parameter in many places, and use directly from compilationOptions