### PR TITLE
fix: remove some remnants of namespace in pkg/observe

### DIFF
--- a/cmd/subcommands/cpu.go
+++ b/cmd/subcommands/cpu.go
@@ -42,7 +42,7 @@ func Newcmd() *cobra.Command {
 			return err
 		}
 
-		return cpu.UI(ctx, maybeRun, backend, cpu.CpuOptions{Namespace: opts.Target.Namespace, Verbose: opts.Log.Verbose, IntervalSeconds: intervalSecondsFlag})
+		return cpu.UI(ctx, maybeRun, backend, cpu.CpuOptions{Verbose: opts.Log.Verbose, IntervalSeconds: intervalSecondsFlag})
 	}
 
 	return cmd

--- a/pkg/be/controller/controller.go
+++ b/pkg/be/controller/controller.go
@@ -4,5 +4,5 @@ import "context"
 
 type Controller interface {
 	// Reconfigure a pool to have a `delta` number of workers
-	ChangeWorkers(ctx context.Context, poolName, poolNamespace, context string, delta int) error
+	ChangeWorkers(ctx context.Context, poolName, context string, delta int) error
 }

--- a/pkg/be/events/component.go
+++ b/pkg/be/events/component.go
@@ -6,12 +6,11 @@ import (
 )
 
 type ComponentUpdate struct {
-	Component lunchpail.Component
-	Status    WorkerStatus
-	Type      EventType
+	lunchpail.Component
+	Status WorkerStatus
+	Type   EventType
 
-	Name      string
-	Namespace string
-	Pool      string
-	Ctrl      controller.Controller
+	Name string
+	Pool string
+	Ctrl controller.Controller
 }

--- a/pkg/be/events/updates.go
+++ b/pkg/be/events/updates.go
@@ -13,16 +13,16 @@ const (
 	Modified           = "modified"
 )
 
-func DispatcherUpdate(namespace string, ctrl controller.Controller, status WorkerStatus, event EventType) ComponentUpdate {
+func DispatcherUpdate(ctrl controller.Controller, status WorkerStatus, event EventType) ComponentUpdate {
 	name := lunchpail.ComponentShortName(lunchpail.DispatcherComponent)
-	return ComponentUpdate{lunchpail.DispatcherComponent, status, event, name, namespace, "", ctrl}
+	return ComponentUpdate{lunchpail.DispatcherComponent, status, event, name, "", ctrl}
 }
 
-func WorkStealerUpdate(namespace string, ctrl controller.Controller, status WorkerStatus, event EventType) ComponentUpdate {
+func WorkStealerUpdate(ctrl controller.Controller, status WorkerStatus, event EventType) ComponentUpdate {
 	name := lunchpail.ComponentShortName(lunchpail.WorkStealerComponent)
-	return ComponentUpdate{lunchpail.WorkStealerComponent, status, event, name, namespace, "", ctrl}
+	return ComponentUpdate{lunchpail.WorkStealerComponent, status, event, name, "", ctrl}
 }
 
-func WorkerUpdate(name, namespace, pool string, ctrl controller.Controller, status WorkerStatus, event EventType) ComponentUpdate {
-	return ComponentUpdate{lunchpail.WorkersComponent, status, event, name, namespace, pool, ctrl}
+func WorkerUpdate(name, pool string, ctrl controller.Controller, status WorkerStatus, event EventType) ComponentUpdate {
+	return ComponentUpdate{lunchpail.WorkersComponent, status, event, name, pool, ctrl}
 }

--- a/pkg/be/kubernetes/pool.go
+++ b/pkg/be/kubernetes/pool.go
@@ -11,7 +11,7 @@ import (
 	"lunchpail.io/pkg/lunchpail"
 )
 
-func (backend Backend) ChangeWorkers(ctx context.Context, poolName, poolNamespace, poolContext string, delta int) error {
+func (backend Backend) ChangeWorkers(ctx context.Context, poolName, poolContext string, delta int) error {
 	// TODO handle poolContext!!!
 	clientset, _, err := Client()
 	if err != nil {
@@ -20,7 +20,7 @@ func (backend Backend) ChangeWorkers(ctx context.Context, poolName, poolNamespac
 
 	k8sName := shell.ResourceName(poolName, lunchpail.WorkersComponent)
 
-	jobsClient := clientset.BatchV1().Jobs(poolNamespace)
+	jobsClient := clientset.BatchV1().Jobs(backend.namespace)
 	job, err := jobsClient.Get(ctx, k8sName, metav1.GetOptions{})
 	if err != nil {
 		return err

--- a/pkg/be/kubernetes/updates.go
+++ b/pkg/be/kubernetes/updates.go
@@ -77,7 +77,7 @@ func (streamer Streamer) updateFromPod(pod *v1.Pod, what watch.EventType, cc cha
 				return err
 			}
 		}
-		cc <- events.WorkStealerUpdate(pod.Namespace, streamer.backend, workerStatus, events.EventType(what))
+		cc <- events.WorkStealerUpdate(streamer.backend, workerStatus, events.EventType(what))
 	case string(lunchpail.DispatcherComponent):
 		if what == watch.Added {
 			// new dispatcher pod. start streaming its logs
@@ -85,11 +85,11 @@ func (streamer Streamer) updateFromPod(pod *v1.Pod, what watch.EventType, cc cha
 				return err
 			}
 		}
-		cc <- events.DispatcherUpdate(pod.Namespace, streamer.backend, workerStatus, events.EventType(what))
+		cc <- events.DispatcherUpdate(streamer.backend, workerStatus, events.EventType(what))
 	case string(lunchpail.WorkersComponent):
 		if what == watch.Added {
 			// new worker pod. start streaming its logs
-			if err := streamLogUpdatesForWorker(streamer.Context, pod.Name, pod.Namespace, cm); err != nil {
+			if err := streamLogUpdatesForWorker(streamer.Context, pod.Name, streamer.backend.namespace, cm); err != nil {
 				return err
 			} else {
 				// TODO: are we leaking something
@@ -104,7 +104,7 @@ func (streamer Streamer) updateFromPod(pod *v1.Pod, what watch.EventType, cc cha
 			return fmt.Errorf("Worker without pool name label %s\n", pod.Name)
 		}
 
-		cc <- events.WorkerUpdate(pod.Name, pod.Namespace, poolName, streamer.backend, workerStatus, events.EventType(what))
+		cc <- events.WorkerUpdate(pod.Name, poolName, streamer.backend, workerStatus, events.EventType(what))
 	}
 
 	return nil

--- a/pkg/be/local/streamer.go
+++ b/pkg/be/local/streamer.go
@@ -84,11 +84,11 @@ func (s localStreamer) RunComponentUpdates(cc chan events.ComponentUpdate, cm ch
 							dashIdx := strings.LastIndex(instanceName, "-")
 							poolName := instanceName[:dashIdx]
 							workerName := instanceName
-							cc <- events.WorkerUpdate(workerName, "", poolName, ctrl, state, event)
+							cc <- events.WorkerUpdate(workerName, poolName, ctrl, state, event)
 						case lunchpail.WorkStealerComponent:
-							cc <- events.WorkStealerUpdate("", ctrl, state, event)
+							cc <- events.WorkStealerUpdate(ctrl, state, event)
 						case lunchpail.DispatcherComponent:
-							cc <- events.DispatcherUpdate("", ctrl, state, event)
+							cc <- events.DispatcherUpdate(ctrl, state, event)
 						}
 					}
 				}

--- a/pkg/observe/cpu/ui.go
+++ b/pkg/observe/cpu/ui.go
@@ -10,7 +10,6 @@ import (
 )
 
 type CpuOptions struct {
-	Namespace       string
 	Verbose         bool
 	IntervalSeconds int
 }

--- a/pkg/observe/status/model.go
+++ b/pkg/observe/status/model.go
@@ -20,7 +20,6 @@ type Worker struct {
 
 type Pool struct {
 	Name        string
-	Namespace   string
 	Parallelism int
 	Ctrl        controller.Controller
 	Workers     []Worker
@@ -138,5 +137,5 @@ func (pool *Pool) qsummary() (int, int, int, int) {
 
 func (pool *Pool) changeWorkers(ctx context.Context, delta int) error {
 	context := "" // TODO
-	return pool.Ctrl.ChangeWorkers(ctx, pool.Name, pool.Namespace, context, delta)
+	return pool.Ctrl.ChangeWorkers(ctx, pool.Name, context, delta)
 }

--- a/pkg/observe/status/worker.go
+++ b/pkg/observe/status/worker.go
@@ -24,7 +24,7 @@ func updateWorker(update events.ComponentUpdate, pools []Pool) ([]Pool, error) {
 			// Added or Modified a Worker in a Pool we
 			// haven't seen yet; create a record of both
 			// the Pool and the Worker
-			pool := Pool{update.Pool, update.Namespace, 1, update.Ctrl, []Worker{Worker{name, workerStatus, qstat.Worker{}}}}
+			pool := Pool{update.Pool, 1, update.Ctrl, []Worker{Worker{name, workerStatus, qstat.Worker{}}}}
 			return append(pools, pool), nil
 		}
 	}


### PR DESCRIPTION
The concept of namespace should be isolated to the backend impls.