### PR TITLE
fix: restore original pool name label

### DIFF
--- a/pkg/be/kubernetes/shell/chart/templates/podlabels.yaml
+++ b/pkg/be/kubernetes/shell/chart/templates/podlabels.yaml
@@ -6,7 +6,7 @@ labels:
 {{- define "labels" }}
 app.kubernetes.io/component: {{ $.Values.lunchpail.component }}
 app.kubernetes.io/part-of: {{ $.Values.lunchpail.partOf }}
-app.kubernetes.io/name: {{ $.Values.lunchpail.instanceName }}
-app.kubernetes.io/instance: {{ $.Values.lunchpail.name }}
+app.kubernetes.io/name: {{ $.Values.lunchpail.groupName }} # e.g. orig. name of workerpool
+app.kubernetes.io/instance: {{ $.Values.lunchpail.name }} # run name
 app.kubernetes.io/managed-by: lunchpail.io
 {{- end }}

--- a/pkg/be/kubernetes/shell/template.go
+++ b/pkg/be/kubernetes/shell/template.go
@@ -49,8 +49,14 @@ func Template(ir llir.LLIR, c llir.ShellComponent, namespace string, opts common
 		return "", err
 	}
 
+	groupName := c.GroupName
+	if groupName == "" {
+		groupName = c.InstanceName
+	}
+
 	// values for this component
 	myValues := []string{
+		"lunchpail.groupName=" + util.TrimToMax(groupName, 63),         // in kubernetes, labels must have a max length of 63 chars
 		"lunchpail.instanceName=" + util.TrimToMax(c.InstanceName, 63), // in kubernetes, labels must have a max length of 63 chars
 		"lunchpail.component=" + string(c.Component),
 		"image=" + c.Application.Spec.Image,

--- a/pkg/fe/transformer/api/workerpool/lower.go
+++ b/pkg/fe/transformer/api/workerpool/lower.go
@@ -17,6 +17,7 @@ func Lower(compilationName, runname string, app hlir.Application, pool hlir.Work
 
 	spec.RunAsJob = true
 	spec.Sizing = api.WorkerpoolSizing(pool, app, opts)
+	spec.GroupName = pool.Metadata.Name
 	spec.InstanceName = fmt.Sprintf("%s-%s", pool.Metadata.Name, runname)
 	spec.QueuePrefixPath = api.QueuePrefixPathForWorker(ir.Queue, runname, pool.Metadata.Name)
 

--- a/pkg/ir/llir/shell.go
+++ b/pkg/ir/llir/shell.go
@@ -14,8 +14,11 @@ type ShellComponent struct {
 	// Use a Job-style (versus Pod-style) of deployment?
 	RunAsJob bool
 
-	// Defaults to run name
+	// Identifies this component instance
 	InstanceName string
+
+	// Identifies the group this component is part of, e.g. the original name of the workerpool (i.e. without run id, component, ...)
+	GroupName string
 
 	// Where runners of this instance should pick up or dispatch queue data
 	QueuePrefixPath string


### PR DESCRIPTION
This adds a GroupName field to llir.ShellComponent to allow for this distinction between instance name and ... pool name