### PR TITLE
refactor: eliminate linker.ConfigureOptions

### DIFF
--- a/cmd/subcommands/up.go
+++ b/cmd/subcommands/up.go
@@ -11,7 +11,6 @@ import (
 	"lunchpail.io/pkg/be"
 	"lunchpail.io/pkg/boot"
 	"lunchpail.io/pkg/compilation"
-	"lunchpail.io/pkg/fe/linker"
 	"lunchpail.io/pkg/util"
 )
 
@@ -58,15 +57,13 @@ func newUpCmd() *cobra.Command {
 		compilationOpts.OverrideValues = append(compilationOpts.OverrideValues, overrideValues...)
 		compilationOpts.OverrideFileValues = append(compilationOpts.OverrideFileValues, overrideFileValues...)
 
-		configureOptions := linker.ConfigureOptions{CompilationOptions: *compilationOpts}
-
 		ctx := context.Background()
 		backend, err := be.NewInitOk(ctx, createCluster, *compilationOpts)
 		if err != nil {
 			return err
 		}
 
-		return boot.Up(ctx, backend, boot.UpOptions{ConfigureOptions: configureOptions, DryRun: dryrunFlag, Watch: watchFlag})
+		return boot.Up(ctx, backend, boot.UpOptions{CompilationOptions: *compilationOpts, DryRun: dryrunFlag, Watch: watchFlag})
 	}
 
 	return cmd

--- a/pkg/boot/down.go
+++ b/pkg/boot/down.go
@@ -10,7 +10,6 @@ import (
 	"lunchpail.io/pkg/be"
 	"lunchpail.io/pkg/be/runs/util"
 	"lunchpail.io/pkg/compilation"
-	"lunchpail.io/pkg/fe/linker"
 )
 
 type DownOptions struct {
@@ -74,18 +73,13 @@ func toCompilationOpts(opts DownOptions) compilation.Options {
 }
 
 func toUpOpts(runname string, opts DownOptions) UpOptions {
-	configureOptions := linker.ConfigureOptions{}
-	configureOptions.CompilationOptions = toCompilationOpts(opts)
-	if configureOptions.CompilationOptions.Log == nil {
-		configureOptions.CompilationOptions.Log = &compilation.LogOptions{}
+	compilationOptions := toCompilationOpts(opts)
+	if compilationOptions.Log == nil {
+		compilationOptions.Log = &compilation.LogOptions{}
 	}
-	configureOptions.CompilationOptions.Log.Verbose = opts.Verbose
+	compilationOptions.Log.Verbose = opts.Verbose
 
-	upOptions := UpOptions{}
-	upOptions.ConfigureOptions = configureOptions
-	upOptions.UseThisRunName = runname
-
-	return upOptions
+	return UpOptions{CompilationOptions: compilationOptions, UseThisRunName: runname}
 }
 
 func Down(ctx context.Context, runname string, backend be.Backend, opts DownOptions) error {

--- a/pkg/fe/linker/configure.go
+++ b/pkg/fe/linker/configure.go
@@ -10,16 +10,12 @@ import (
 	"lunchpail.io/pkg/lunchpail"
 )
 
-type ConfigureOptions struct {
-	CompilationOptions compilation.Options
-}
-
-func Configure(appname, runname, templatePath string, internalS3Port int, opts ConfigureOptions) (string, []string, []string, queue.Spec, error) {
-	if opts.CompilationOptions.Log.Verbose {
+func Configure(appname, runname, templatePath string, internalS3Port int, opts compilation.Options) (string, []string, []string, queue.Spec, error) {
+	if opts.Log.Verbose {
 		fmt.Fprintf(os.Stderr, "Stage directory for runname=%s is %s\n", runname, templatePath)
 	}
 
-	queueSpec, err := queue.ParseFlag(opts.CompilationOptions.Queue, runname, internalS3Port)
+	queueSpec, err := queue.ParseFlag(opts.Queue, runname, internalS3Port)
 	if err != nil {
 		return "", nil, nil, queue.Spec{}, err
 	}
@@ -62,14 +58,14 @@ lunchpail:
 		appname,                 // (16)
 	)
 
-	if opts.CompilationOptions.Log.Verbose {
+	if opts.Log.Verbose {
 		fmt.Fprintf(os.Stderr, "shrinkwrap app values=%s\n", yaml)
-		fmt.Fprintf(os.Stderr, "shrinkwrap app overrides=%v\n", opts.CompilationOptions.OverrideValues)
-		fmt.Fprintf(os.Stderr, "shrinkwrap app file overrides=%v\n", opts.CompilationOptions.OverrideFileValues)
+		fmt.Fprintf(os.Stderr, "shrinkwrap app overrides=%v\n", opts.OverrideValues)
+		fmt.Fprintf(os.Stderr, "shrinkwrap app file overrides=%v\n", opts.OverrideFileValues)
 	}
 
-	overrides := opts.CompilationOptions.OverrideValues
-	fileOverrides := opts.CompilationOptions.OverrideFileValues
+	overrides := opts.OverrideValues
+	fileOverrides := opts.OverrideFileValues
 
 	return yaml, overrides, fileOverrides, queueSpec, nil
 }

--- a/pkg/fe/prepare-run.go
+++ b/pkg/fe/prepare-run.go
@@ -14,10 +14,10 @@ import (
 )
 
 type CompileOptions struct {
-	linker.ConfigureOptions
-	DryRun         bool
-	Watch          bool
-	UseThisRunName string
+	CompilationOptions compilation.Options
+	DryRun             bool
+	Watch              bool
+	UseThisRunName     string
 }
 
 func PrepareForRun(opts CompileOptions) (llir.LLIR, compilation.Options, error) {
@@ -43,7 +43,7 @@ func PrepareForRun(opts CompileOptions) (llir.LLIR, compilation.Options, error) 
 		fmt.Fprintf(os.Stderr, "Using internal S3 port %d\n", internalS3Port)
 	}
 
-	yamlValues, dashdashSetValues, dashdashSetFileValues, queueSpec, err := linker.Configure(compilationName, runname, templatePath, internalS3Port, opts.ConfigureOptions)
+	yamlValues, dashdashSetValues, dashdashSetFileValues, queueSpec, err := linker.Configure(compilationName, runname, templatePath, internalS3Port, opts.CompilationOptions)
 	if err != nil {
 		return llir.LLIR{}, opts.CompilationOptions, err
 	}
@@ -58,7 +58,7 @@ func PrepareForRun(opts CompileOptions) (llir.LLIR, compilation.Options, error) 
 		return llir.LLIR{}, opts.CompilationOptions, err
 	} else if hlir, err := parser.Parse(yaml); err != nil {
 		return llir.LLIR{}, opts.CompilationOptions, err
-	} else if ir, err := transformer.Lower(compilationName, runname, hlir, queueSpec, opts.ConfigureOptions.CompilationOptions); err != nil {
+	} else if ir, err := transformer.Lower(compilationName, runname, hlir, queueSpec, opts.CompilationOptions); err != nil {
 		return llir.LLIR{}, opts.CompilationOptions, err
 	} else {
 		return ir, opts.CompilationOptions, nil


### PR DESCRIPTION
It had become a wrapper over compilation.Options