### PR TITLE
feat: update runtime/queue/CopyIn to accept an array of files/paths to copy in

### DIFF
--- a/cmd/subcommands/qin.go
+++ b/cmd/subcommands/qin.go
@@ -38,7 +38,7 @@ func newQcopyinCmd() *cobra.Command {
 			return err
 		}
 
-		return queue.CopyIn(ctx, backend, runname, args[0], args[1])
+		return queue.CopyIn(ctx, backend, runname, []queue.CopyInSpec{queue.CopyInSpec{SrcDir: args[0], Bucket: args[1]}})
 	}
 
 	return cmd

--- a/pkg/runtime/queue/copyin.go
+++ b/pkg/runtime/queue/copyin.go
@@ -12,37 +12,44 @@ import (
 	"lunchpail.io/pkg/be"
 )
 
-func CopyIn(ctx context.Context, backend be.Backend, runname, srcDir, bucket string) error {
+type CopyInSpec struct {
+	SrcDir string
+	Bucket string
+}
+
+func CopyIn(ctx context.Context, backend be.Backend, runname string, specs []CopyInSpec) error {
 	s3, stop, err := NewS3ClientForRun(ctx, backend, runname)
 	if err != nil {
 		return err
 	}
 	defer stop()
 
-	fmt.Fprintf(os.Stderr, "Preparing upload with mkdirp on s3 bucket=%s\n", bucket)
-	if err := s3.Mkdirp(bucket); err != nil {
-		return err
-	}
-
-	fmt.Fprintf(os.Stderr, "Uploading files from local directory=%s to s3 bucket=%s\n", srcDir, bucket)
-	if err := filepath.WalkDir(srcDir, func(path string, dir fs.DirEntry, err error) error {
-		if err != nil {
+	for _, spec := range specs {
+		fmt.Fprintf(os.Stderr, "Preparing upload with mkdirp on s3 bucket=%s\n", spec.Bucket)
+		if err := s3.Mkdirp(spec.Bucket); err != nil {
 			return err
-		} else if !dir.IsDir() {
-			for i := range 10 {
-				dst := strings.Replace(path, srcDir+"/", "", 1)
-				fmt.Fprintf(os.Stderr, "Uploading %s to s3 %s\n", path, dst)
-				if err := s3.Upload(bucket, path, dst); err == nil {
-					break
-				} else {
-					fmt.Fprintf(os.Stderr, "Retrying upload iter=%d path=%s\n%v\n", i, path, err)
-					time.Sleep(1 * time.Second)
+		}
+
+		fmt.Fprintf(os.Stderr, "Uploading files from local directory=%s to s3 bucket=%s\n", spec.SrcDir, spec.Bucket)
+		if err := filepath.WalkDir(spec.SrcDir, func(path string, dir fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			} else if !dir.IsDir() {
+				for i := range 10 {
+					dst := strings.Replace(path, spec.SrcDir+"/", "", 1)
+					fmt.Fprintf(os.Stderr, "Uploading %s to s3 %s\n", path, dst)
+					if err := s3.Upload(spec.Bucket, path, dst); err == nil {
+						break
+					} else {
+						fmt.Fprintf(os.Stderr, "Retrying upload iter=%d path=%s\n%v\n", i, path, err)
+						time.Sleep(1 * time.Second)
+					}
 				}
 			}
+			return nil
+		}); err != nil {
+			return err
 		}
-		return nil
-	}); err != nil {
-		return err
 	}
 
 	return nil


### PR DESCRIPTION
i.e. rather than just a single one, to allow callers to amortize the cost of setting up the AccessQueue