### PR TITLE
feat: rename qin/copyin -> upload

### DIFF
--- a/cmd/subcommands/upload.go
+++ b/cmd/subcommands/upload.go
@@ -11,11 +11,12 @@ import (
 	"lunchpail.io/pkg/be"
 	"lunchpail.io/pkg/compilation"
 	"lunchpail.io/pkg/runtime/queue"
+	"lunchpail.io/pkg/runtime/queue/upload"
 )
 
-func newQcopyinCmd() *cobra.Command {
+func newUploadCmd() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "qin <srcDir> <bucket>",
+		Use:   "upload <srcDir> <bucket>",
 		Short: "Copy data into queue",
 		Long:  "Copy data into queue",
 		Args:  cobra.MatchAll(cobra.ExactArgs(2), cobra.OnlyValidArgs),
@@ -38,7 +39,7 @@ func newQcopyinCmd() *cobra.Command {
 			return err
 		}
 
-		return queue.CopyIn(ctx, backend, runname, []queue.CopyInSpec{queue.CopyInSpec{Path: args[0], Bucket: args[1]}})
+		return queue.UploadFiles(ctx, backend, runname, []upload.Upload{upload.Upload{Path: args[0], Bucket: args[1]}})
 	}
 
 	return cmd
@@ -46,6 +47,6 @@ func newQcopyinCmd() *cobra.Command {
 
 func init() {
 	if compilation.IsCompiled() {
-		rootCmd.AddCommand(newQcopyinCmd())
+		rootCmd.AddCommand(newUploadCmd())
 	}
 }

--- a/pkg/runtime/queue/upload.go
+++ b/pkg/runtime/queue/upload.go
@@ -11,14 +11,10 @@ import (
 	"time"
 
 	"lunchpail.io/pkg/be"
+	"lunchpail.io/pkg/runtime/queue/upload"
 )
 
-type CopyInSpec struct {
-	Path   string
-	Bucket string
-}
-
-func CopyIn(ctx context.Context, backend be.Backend, runname string, specs []CopyInSpec) error {
+func UploadFiles(ctx context.Context, backend be.Backend, runname string, specs []upload.Upload) error {
 	s3, stop, err := NewS3ClientForRun(ctx, backend, runname)
 	if err != nil {
 		return err
@@ -54,7 +50,7 @@ func CopyIn(ctx context.Context, backend be.Backend, runname string, specs []Cop
 	return nil
 }
 
-func (s3 S3Client) copyInDir(spec CopyInSpec) error {
+func (s3 S3Client) copyInDir(spec upload.Upload) error {
 	return filepath.WalkDir(spec.Path, func(path string, dir fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -65,7 +61,7 @@ func (s3 S3Client) copyInDir(spec CopyInSpec) error {
 	})
 }
 
-func (s3 S3Client) copyInFile(path string, spec CopyInSpec) error {
+func (s3 S3Client) copyInFile(path string, spec upload.Upload) error {
 	for i := range 10 {
 		dst := strings.Replace(path, spec.Path+"/", "", 1)
 		fmt.Fprintf(os.Stderr, "Uploading %s to s3 %s\n", path, dst)

--- a/pkg/runtime/queue/upload/upload.go
+++ b/pkg/runtime/queue/upload/upload.go
@@ -1,0 +1,6 @@
+package upload
+
+type Upload struct {
+	Path   string
+	Bucket string
+}

--- a/tests/bin/add-data.sh
+++ b/tests/bin/add-data.sh
@@ -19,6 +19,6 @@ for bucket_path in $@; do
     if [[ -d $bucket_path ]]; then
         bucket=$(basename $bucket_path)
         echo "$(tput setaf 2)Populating s3 app=$testapp target=${LUNCHPAIL_TARGET:-kubernetes} bucket=$bucket from $bucket_path$(tput sgr0)"
-        $testapp qin $bucket_path $bucket --target ${LUNCHPAIL_TARGET:-kubernetes}
+        $testapp upload $bucket_path $bucket --target ${LUNCHPAIL_TARGET:-kubernetes}
     fi
 done


### PR DESCRIPTION
This is to avoid confusion with the *other* way we have been using "copy in", to mean "copy in to the worker/pod". I think that other meaning is better, because it aligns with existing "copy-in/copy-out" terminology. What we really meant by qin is "upload from my laptop to the s3/queue storage".