### PR TITLE
fix: local backend segfaults with `up --verbose`

### DIFF
--- a/pkg/be/local/streamer.go
+++ b/pkg/be/local/streamer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -253,8 +254,7 @@ func (s localStreamer) ComponentLogs(c lunchpail.Component, opts streamer.LogOpt
 func tailfChan(outfile string, opts streamer.LogOptions) (*tail.Tail, error) {
 	Logger := tail.DiscardingLogger
 	if opts.Verbose {
-		// this tells tailf to use its default logger
-		Logger = nil
+		Logger = log.New(os.Stderr, "", log.LstdFlags)
 	}
 
 	return tail.TailFile(outfile, tail.Config{Follow: opts.Follow, ReOpen: opts.Follow, Logger: Logger})


### PR DESCRIPTION
We were passing Logger=nil to the Tail package, which is what its docs state will result in using its default logger. Unfortunately we rather see a null pointer segfault.