### PR TITLE
fix: avoid underscores in build.Name

### DIFF
--- a/pkg/fe/builder/build.go
+++ b/pkg/fe/builder/build.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 
 	"golang.org/x/sync/errgroup"
@@ -56,6 +57,8 @@ func Build(ctx context.Context, sourcePath string, opts Options) error {
 			buildName = filepath.Base(filepath.Dir(filepath.Dir(trimExt(sourcePath))))
 		}
 	}
+	// replace _ with -
+	buildName = regexp.MustCompile("_").ReplaceAllString(buildName, "-")
 
 	if verbose {
 		fmt.Fprintf(os.Stderr, "Using buildName=%s\n", buildName)


### PR DESCRIPTION
Two problems: kubernetes is not happy with underscores; and s3 is not either for a bucket name.