### PR TITLE
fix: `up --dry-run` with kubernetes backend emits trailing EXTRA nil garbage

### DIFF
--- a/pkg/boot/up.go
+++ b/pkg/boot/up.go
@@ -30,7 +30,11 @@ func Up(ctx context.Context, backend be.Backend, opts UpOptions) error {
 	}
 
 	if opts.DryRun {
-		fmt.Printf(backend.DryRun(ir, opts.BuildOptions))
+		out, err := backend.DryRun(ir, opts.BuildOptions)
+		if err != nil {
+			return err
+		}
+		fmt.Printf(out)
 		return nil
 	}
 


### PR DESCRIPTION
We were fmt.Printf’ing something that returned a pair `(string, error)`

Fixes #187