### PR TITLE
fix: `queue add --wait` should use notification when available

### DIFF
--- a/pkg/runtime/queue/wait.go
+++ b/pkg/runtime/queue/wait.go
@@ -4,25 +4,66 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
 	"strconv"
 	"time"
+
+	"github.com/minio/minio-go/v7/pkg/notification"
 )
 
-func (c S3Client) WaitForCompletion(task string, verbose bool) (int, error) {
+func (s3 S3Client) waitForBucket(bucket string) error {
+	// TODO use notifications
 	for {
-		doneTasks, err := c.Lsf(c.Paths.Bucket, filepath.Join(c.Paths.PoolPrefix, c.Paths.Outbox))
+		exists, err := s3.BucketExists(bucket)
 		if err != nil {
-			return 0, err
+			return err
+		} else if !exists {
+			fmt.Fprintf(os.Stderr, "Waiting for bucket %s\n", bucket)
+			time.Sleep(1 * time.Second)
+		} else {
+			break
+		}
+	}
+
+	return nil
+}
+
+func (s3 S3Client) WaitForEvent(bucket, object, event string) error {
+	defer s3.StopListening(bucket)
+
+	suffix := ""
+	for notificationInfo := range s3.client.ListenBucketNotification(s3.context, bucket, object, suffix, []string{event}) {
+		if notificationInfo.Err != nil {
+			return notificationInfo.Err
 		}
 
-		if idx := slices.IndexFunc(doneTasks, func(otask string) bool { return otask == task }); idx >= 0 {
-			break
-		} else {
-			if verbose {
-				fmt.Fprintf(os.Stderr, "Still waiting for task completion %s. Here is what is done so far: %v\n", task, doneTasks)
-			}
-			time.Sleep(3 * time.Second)
+		break
+	}
+
+	return nil
+}
+
+func (s3 S3Client) WaitTillExists(bucket, object string) error {
+	return s3.WaitForEvent(bucket, object, "s3:ObjectCreated:*")
+}
+
+func (s3 S3Client) Listen(bucket, prefix, suffix string) <-chan notification.Info {
+	return s3.client.ListenBucketNotification(s3.context, bucket, prefix, suffix, []string{"s3:ObjectCreated:*"})
+}
+
+func (s3 S3Client) StopListening(bucket string) error {
+	return s3.client.RemoveAllBucketNotification(s3.context, bucket)
+}
+
+// Wait for the given enqueued task to appear in the outbox
+func (c S3Client) WaitForCompletion(task string, verbose bool) (int, error) {
+	bucket := c.Paths.Bucket
+	outbox := filepath.Join(c.Paths.PoolPrefix, c.Paths.Outbox)
+	outFile := filepath.Join(outbox, task)
+	codeFile := filepath.Join(outbox, task+".code")
+
+	if err := c.WaitTillExists(bucket, outFile); err != nil {
+		if err := c.waitTillExistsViaPolling(bucket, outFile, verbose); err != nil {
+			return 0, err
 		}
 	}
 
@@ -30,8 +71,7 @@ func (c S3Client) WaitForCompletion(task string, verbose bool) (int, error) {
 		fmt.Fprintf(os.Stderr, "Task completed %s\n", task)
 	}
 
-	codeFile := filepath.Join(c.Paths.PoolPrefix, c.Paths.Outbox, task+".code")
-	if code, err := c.Get(c.Paths.Bucket, codeFile); err != nil {
+	if code, err := c.Get(bucket, codeFile); err != nil {
 		return 0, err
 	} else {
 		if verbose {
@@ -44,4 +84,26 @@ func (c S3Client) WaitForCompletion(task string, verbose bool) (int, error) {
 		}
 		return exitcode, nil
 	}
+}
+
+func (c S3Client) waitTillExistsViaPolling(bucket, prefix string, verbose bool) error {
+	task := filepath.Base(prefix)
+
+	for {
+		doneTasks, err := c.Lsf(bucket, prefix)
+		if err != nil {
+			return err
+		}
+
+		if len(doneTasks) > 0 {
+			break
+		} else {
+			if verbose {
+				fmt.Fprintf(os.Stderr, "Still waiting for task completion %s. Here is what is done so far: %v\n", task, doneTasks)
+			}
+			time.Sleep(3 * time.Second)
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
Also:
- refactor cleanups to consolidate s3 waiting logic in the existing wait.go file
- simplify the existing polling logic to call Lsf on the specific file we are looking for