### PR TITLE
fix: push notifications may miss some objects

### DIFF
--- a/pkg/runtime/queue/paths.go
+++ b/pkg/runtime/queue/paths.go
@@ -6,6 +6,11 @@ import (
 	"strings"
 )
 
+const (
+	inboxFolder  = "inbox"
+	outboxFolder = "outbox"
+)
+
 type filepaths struct {
 	Bucket     string
 	PoolPrefix string
@@ -39,9 +44,9 @@ func pathsFor(queuePrefixPath string) (filepaths, error) {
 	bucket := fullPrefix[0]
 	poolPrefix := filepath.Join(fullPrefix[1:]...)
 	prefix := strings.Replace(filepath.Join(fullPrefix[1:]...), "$LUNCHPAIL_WORKER_NAME", os.Getenv("LUNCHPAIL_POD_NAME"), 1)
-	inbox := "inbox"
+	inbox := inboxFolder
 	processing := "processing"
-	outbox := "outbox"
+	outbox := outboxFolder
 	done := filepath.Join(poolPrefix, "done")
 	alldone := filepath.Join(poolPrefix, "alldone")
 	alive := filepath.Join(prefix, inbox, ".alive")
@@ -54,4 +59,8 @@ func pathsFor(queuePrefixPath string) (filepaths, error) {
 	local := tmpdir
 
 	return filepaths{bucket, poolPrefix, prefix, inbox, processing, outbox, done, alldone, alive, dead, local}, nil
+}
+
+func (c S3Client) Outbox() string {
+	return filepath.Join(c.Paths.PoolPrefix, c.Paths.Outbox)
 }

--- a/pkg/runtime/workstealer/run.go
+++ b/pkg/runtime/workstealer/run.go
@@ -50,12 +50,15 @@ func Run(ctx context.Context) error {
 	}
 
 	defer s3.StopListening(s3.Paths.Bucket)
-	for notification := range s3.Listen(s3.Paths.Bucket, "", "") {
-		if notification.Err != nil {
-			fmt.Fprintln(os.Stderr, notification.Err)
+	o, errs := s3.Listen(s3.Paths.Bucket, "", "")
+	for {
+		select {
+		case err := <-errs:
+			fmt.Fprintln(os.Stderr, err)
 
 			// sleep for a bit
 			time.Sleep(s)
+		case <-o:
 		}
 
 		// fetch model


### PR DESCRIPTION
This updates the Listen() implementation:
- return (chan string, chan error) instead of the minio Notification channel
- list first, then watch, and re-list after first notification; this patches the two race windows in the minio bucket notification (it does not send notifications for objects already in existence)

Fixes #364