### PR TITLE
refactor: upew NewS3ClientForRun to return a stoppable client

### DIFF
--- a/pkg/runtime/queue/ls.go
+++ b/pkg/runtime/queue/ls.go
@@ -9,7 +9,7 @@ import (
 )
 
 func Ls(ctx context.Context, backend be.Backend, runname, path string) (<-chan string, <-chan error, error) {
-	c, stop, err := NewS3ClientForRun(ctx, backend, runname)
+	c, err := NewS3ClientForRun(ctx, backend, runname)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -19,7 +19,7 @@ func Ls(ctx context.Context, backend be.Backend, runname, path string) (<-chan s
 	prefix := filepath.Join(c.Paths.Prefix, path)
 
 	go func() {
-		defer stop()
+		defer c.Stop()
 		defer close(files)
 		defer close(errors)
 		for o := range c.ListObjects(c.Paths.Bucket, prefix, true) {

--- a/pkg/runtime/queue/qcat.go
+++ b/pkg/runtime/queue/qcat.go
@@ -8,16 +8,16 @@ import (
 )
 
 func Qcat(ctx context.Context, backend be.Backend, runname, path string) error {
-	c, stop, err := NewS3ClientForRun(ctx, backend, runname)
+	c, err := NewS3ClientForRun(ctx, backend, runname)
 	if err != nil {
 		return err
 	}
+	defer c.Stop()
 
 	prefix := filepath.Join(c.Paths.Prefix, path)
 	if err := c.Cat(c.Paths.Bucket, prefix); err != nil {
 		return err
 	}
 
-	stop()
 	return nil
 }

--- a/pkg/runtime/queue/upload.go
+++ b/pkg/runtime/queue/upload.go
@@ -15,11 +15,11 @@ import (
 )
 
 func UploadFiles(ctx context.Context, backend be.Backend, runname string, specs []upload.Upload) error {
-	s3, stop, err := NewS3ClientForRun(ctx, backend, runname)
+	s3, err := NewS3ClientForRun(ctx, backend, runname)
 	if err != nil {
 		return err
 	}
-	defer stop()
+	defer s3.Stop()
 
 	for _, spec := range specs {
 		fmt.Fprintf(os.Stderr, "Preparing upload with mkdirp on s3 bucket=%s\n", spec.Bucket)


### PR DESCRIPTION
rather than passing back a stop function as a separate return value that needs to be propagated around by the caller