### PR TITLE
refactor: split out the upload and download logic into builtins.Cat() and builtins.Redirect()

### DIFF
--- a/pkg/boot/io.go
+++ b/pkg/boot/io.go
@@ -1,0 +1,46 @@
+package boot
+
+import (
+	"context"
+	"path/filepath"
+	"slices"
+
+	"lunchpail.io/pkg/be"
+	"lunchpail.io/pkg/build"
+	"lunchpail.io/pkg/ir/llir"
+	"lunchpail.io/pkg/runtime/builtins"
+	"lunchpail.io/pkg/runtime/queue"
+)
+
+// Behave like `cat inputs | ... > outputs`
+func catAndRedirect(ctx context.Context, inputs []string, backend be.Backend, ir llir.LLIR, opts build.LogOptions, copyoutDone chan<- struct{}) error {
+	defer func() { copyoutDone <- struct{}{} }()
+
+	client, err := queue.NewS3ClientForRun(ctx, backend, ir.RunName)
+	if err != nil {
+		return err
+	}
+	defer client.Stop()
+
+	if err := builtins.Cat(ctx, client.S3Client, inputs, opts); err != nil {
+		return err
+	}
+
+	// TODO: backend.Wait(ir)? which would be a no-op for local
+
+	// If we aren't piped into anything, then copy out the outbox files
+	if true /*!util.StdoutIsTty()*/ {
+		folderFor := func(output string) string {
+			inIdx := slices.IndexFunc(inputs, func(in string) bool { return filepath.Base(in) == output })
+			if inIdx >= 0 {
+				return filepath.Dir(inputs[inIdx])
+			}
+			return "."
+		}
+		if err := builtins.RedirectTo(ctx, client.S3Client, folderFor, opts); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/runtime/builtins/cat.go
+++ b/pkg/runtime/builtins/cat.go
@@ -1,0 +1,35 @@
+package builtins
+
+import (
+	"context"
+
+	"lunchpail.io/pkg/be"
+	"lunchpail.io/pkg/build"
+	"lunchpail.io/pkg/runtime/queue"
+)
+
+func Cat(ctx context.Context, client queue.S3Client, inputs []string, opts build.LogOptions) error {
+	qopts := queue.AddOptions{
+		S3Client:   client,
+		LogOptions: opts,
+	}
+	if err := queue.AddList(ctx, inputs, qopts); err != nil {
+		return err
+	}
+
+	if err := queue.QdoneClient(ctx, client, opts); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func CatClient(ctx context.Context, backend be.Backend, runname string, inputs []string, opts build.LogOptions) error {
+	client, err := queue.NewS3ClientForRun(ctx, backend, runname)
+	if err != nil {
+		return err
+	}
+	defer client.Stop()
+
+	return Cat(ctx, client.S3Client, inputs, opts)
+}


### PR DESCRIPTION
This is entirely refactoring, there should be neither features nor semantic changes.