### PR TITLE
fix: first pass of cleaning up s3 paths: workstealer

### DIFF
--- a/cmd/subcommands/component/workstealer/run.go
+++ b/cmd/subcommands/component/workstealer/run.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/spf13/cobra"
 
+	"lunchpail.io/cmd/options"
 	"lunchpail.io/pkg/runtime/workstealer"
 )
 
@@ -12,11 +13,40 @@ func Run() *cobra.Command {
 		Use:   "run",
 		Short: "Run a work stealer",
 		Long:  "Run a work stealer",
-		Args:  cobra.MatchAll(cobra.OnlyValidArgs),
+		Args:  cobra.MatchAll(cobra.ExactArgs(0), cobra.OnlyValidArgs),
 	}
 
+	unassigned := ""
+	outbox := ""
+	finished := ""
+	workerInbox := ""
+	workerProcessing := ""
+	workerOutbox := ""
+	workerKillfile := ""
+
+	cmd.Flags().StringVar(&unassigned, "unassigned", "", "Where to find unassigned tasks")
+	cmd.MarkFlagRequired("unassigned")
+
+	cmd.Flags().StringVar(&outbox, "outbox", "", "Where to find outbox tasks")
+	cmd.MarkFlagRequired("outbox")
+
+	cmd.Flags().StringVar(&finished, "finished", "", "Where to find finished tasks")
+	cmd.MarkFlagRequired("finished")
+
+	cmd.Flags().StringVar(&workerInbox, "worker-inbox-base", "", "Where to find workerInbox tasks")
+	cmd.MarkFlagRequired("worker-inbox-base")
+	cmd.Flags().StringVar(&workerProcessing, "worker-processing-base", "", "Where to find workerProcessing tasks")
+	cmd.MarkFlagRequired("worker-processing-base")
+	cmd.Flags().StringVar(&workerOutbox, "worker-outbox-base", "", "Where to find workerOutbox tasks")
+	cmd.MarkFlagRequired("worker-outbox-base")
+	cmd.Flags().StringVar(&workerKillfile, "worker-killfile-base", "", "Where to find worker killfile")
+	cmd.MarkFlagRequired("worker-killfile-base")
+
+	lopts := options.AddLogOptions(cmd)
+	ropts := options.AddRequiredRunOptions(cmd)
+
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		return workstealer.Run(context.Background())
+		return workstealer.Run(context.Background(), workstealer.Spec{RunName: ropts.Run, Unassigned: unassigned, Outbox: outbox, Finished: finished, WorkerInbox: workerInbox, WorkerProcessing: workerProcessing, WorkerOutbox: workerOutbox, WorkerKillfile: workerKillfile}, *lopts)
 	}
 
 	return cmd

--- a/pkg/fe/transformer/api/queue.go
+++ b/pkg/fe/transformer/api/queue.go
@@ -41,3 +41,47 @@ func QueuePrefixPathForWorker(queueSpec queue.Spec, runname, poolName string) st
 		QueueSubPathForWorker(poolName, "$LUNCHPAIL_WORKER_NAME"),
 	)
 }
+
+func UnassignedPath(queueSpec queue.Spec, runname string) string {
+	return filepath.Join(QueuePrefixPath(queueSpec, runname), "inbox")
+}
+
+func OutboxPath(queueSpec queue.Spec, runname string) string {
+	return filepath.Join(QueuePrefixPath(queueSpec, runname), "outbox")
+}
+
+func FinishedPath(queueSpec queue.Spec, runname string) string {
+	return filepath.Join(QueuePrefixPath(queueSpec, runname), "finished")
+}
+
+func WorkerKillfilePathBase(queueSpec queue.Spec, runname string) string {
+	return WorkerInboxPathBase(queueSpec, runname)
+}
+
+func WorkerKillfile(base, worker string) string {
+	return filepath.Join(base, worker, "kill")
+}
+
+func WorkerInboxPathBase(queueSpec queue.Spec, runname string) string {
+	return filepath.Join(QueuePrefixPath(queueSpec, runname), "queues")
+}
+
+func WorkerInbox(base, worker, task string) string {
+	return filepath.Join(base, worker, "inbox", task)
+}
+
+func WorkerProcessingPathBase(queueSpec queue.Spec, runname string) string {
+	return WorkerInboxPathBase(queueSpec, runname)
+}
+
+func WorkerProcessing(base, worker, task string) string {
+	return filepath.Join(base, worker, "processing", task)
+}
+
+func WorkerOutboxPathBase(queueSpec queue.Spec, runname string) string {
+	return WorkerInboxPathBase(queueSpec, runname)
+}
+
+func WorkerOutbox(base, worker, task string) string {
+	return filepath.Join(base, worker, "outbox", task)
+}

--- a/pkg/fe/transformer/api/workstealer/lower.go
+++ b/pkg/fe/transformer/api/workstealer/lower.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Lower(buildName, runname string, ir llir.LLIR, opts build.Options) (llir.Component, error) {
-	app, err := transpile(runname)
+	app, err := transpile(runname, ir, *opts.Log)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/fe/transformer/api/workstealer/transpile.go
+++ b/pkg/fe/transformer/api/workstealer/transpile.go
@@ -4,17 +4,20 @@ import (
 	"fmt"
 	"os"
 
+	"lunchpail.io/pkg/build"
+	"lunchpail.io/pkg/fe/transformer/api"
 	"lunchpail.io/pkg/ir/hlir"
+	"lunchpail.io/pkg/ir/llir"
 	"lunchpail.io/pkg/lunchpail"
 )
 
 // Transpile workstealer to hlir.Application
-func transpile(runname string) (hlir.Application, error) {
+func transpile(runname string, ir llir.LLIR, opts build.LogOptions) (hlir.Application, error) {
 	app := hlir.NewApplication(runname + "-workstealer")
 
 	app.Spec.Image = fmt.Sprintf("%s/%s/lunchpail:%s", lunchpail.ImageRegistry, lunchpail.ImageRepo, lunchpail.Version())
 	app.Spec.Role = "workstealer"
-	app.Spec.Command = "$LUNCHPAIL_EXE component workstealer run"
+	app.Spec.Command = fmt.Sprintf("$LUNCHPAIL_EXE component workstealer run --verbose=%v --debug=%v --run %s --unassigned %s --outbox %s --finished %s --worker-inbox-base %s --worker-processing-base %s --worker-outbox-base %s --worker-killfile-base %s", opts.Verbose, opts.Debug, runname, api.UnassignedPath(ir.Queue, runname), api.OutboxPath(ir.Queue, runname), api.FinishedPath(ir.Queue, runname), api.WorkerInboxPathBase(ir.Queue, runname), api.WorkerProcessingPathBase(ir.Queue, runname), api.WorkerOutboxPathBase(ir.Queue, runname), api.WorkerKillfilePathBase(ir.Queue, runname))
 
 	app.Spec.Env = hlir.Env{}
 	app.Spec.Env["LUNCHPAIL_RUN_NAME"] = runname

--- a/pkg/runtime/workstealer/fetch.go
+++ b/pkg/runtime/workstealer/fetch.go
@@ -49,7 +49,7 @@ var processingTaskPattern = regexp.MustCompile("^queues/(.+)/processing/(.+)$")
 var completedTaskPattern = regexp.MustCompile("^queues/(.+)/outbox/(.+)[.](succeeded|failed)$")
 
 // Determine from a changed line the nature of `WhatChanged`
-func whatChanged(line string) (WhatChanged, string, string) {
+func (m *Model) whatChanged(line string) (WhatChanged, string, string) {
 	if match := unassignedTaskPattern.FindStringSubmatch(line); len(match) == 2 {
 		return UnassignedTask, match[1], ""
 	} else if match := dispatcherDonePattern.FindStringSubmatch(line); len(match) == 1 {
@@ -81,7 +81,7 @@ func whatChanged(line string) (WhatChanged, string, string) {
 
 // We will be passed a stream of diffs
 func (m *Model) update(filepath string, workersLookup map[string]Worker) {
-	what, thing, thing2 := whatChanged(filepath)
+	what, thing, thing2 := m.whatChanged(filepath)
 
 	switch what {
 	case UnassignedTask:
@@ -167,7 +167,7 @@ func (c client) fetchModel() Model {
 
 	for o := range c.s3.ListObjects(c.s3.Paths.Bucket, c.s3.Paths.Prefix, true) {
 		if len(o.Key) > l {
-			if debug {
+			if c.LogOptions.Debug {
 				fmt.Fprintf(os.Stderr, "Updating model for: %s\n", o.Key[l:])
 			}
 			m.update(o.Key[l:], workersLookup)

--- a/pkg/runtime/workstealer/report.go
+++ b/pkg/runtime/workstealer/report.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"path/filepath"
 	"text/tabwriter"
 	"time"
 )
@@ -16,24 +15,24 @@ func (model Model) report(c client) error {
 	var b bytes.Buffer
 	writer := tabwriter.NewWriter(&b, 0, 8, 1, '\t', tabwriter.AlignRight)
 
-	fmt.Fprintf(writer, "lunchpail.io\tunassigned\t%d\t\t\t\t\t%s\t%s\n", len(model.UnassignedTasks), run, now.Format(time.UnixDate))
-	fmt.Fprintf(writer, "lunchpail.io\tdispatcherDone\t%v\t\t\t\t\t%s\n", model.DispatcherDone, run)
-	fmt.Fprintf(writer, "lunchpail.io\tassigned\t%d\t\t\t\t\t%s\n", len(model.AssignedTasks), run)
-	fmt.Fprintf(writer, "lunchpail.io\tprocessing\t\t%d\t\t\t\t%s\n", len(model.ProcessingTasks), run)
-	fmt.Fprintf(writer, "lunchpail.io\tdone\t\t\t%d\t%d\t\t%s\n", len(model.SuccessfulTasks), len(model.FailedTasks), run)
-	fmt.Fprintf(writer, "lunchpail.io\tliveworkers\t%d\t\t\t\t\t%s\n", len(model.LiveWorkers), run)
-	fmt.Fprintf(writer, "lunchpail.io\tdeadworkers\t%d\t\t\t\t\t%s\n", len(model.DeadWorkers), run)
+	fmt.Fprintf(writer, "lunchpail.io\tunassigned\t%d\t\t\t\t\t%s\t%s\n", len(model.UnassignedTasks), c.Spec.RunName, now.Format(time.UnixDate))
+	fmt.Fprintf(writer, "lunchpail.io\tdispatcherDone\t%v\t\t\t\t\t%s\n", model.DispatcherDone, c.Spec.RunName)
+	fmt.Fprintf(writer, "lunchpail.io\tassigned\t%d\t\t\t\t\t%s\n", len(model.AssignedTasks), c.Spec.RunName)
+	fmt.Fprintf(writer, "lunchpail.io\tprocessing\t\t%d\t\t\t\t%s\n", len(model.ProcessingTasks), c.Spec.RunName)
+	fmt.Fprintf(writer, "lunchpail.io\tdone\t\t\t%d\t%d\t\t%s\n", len(model.SuccessfulTasks), len(model.FailedTasks), c.Spec.RunName)
+	fmt.Fprintf(writer, "lunchpail.io\tliveworkers\t%d\t\t\t\t\t%s\n", len(model.LiveWorkers), c.Spec.RunName)
+	fmt.Fprintf(writer, "lunchpail.io\tdeadworkers\t%d\t\t\t\t\t%s\n", len(model.DeadWorkers), c.Spec.RunName)
 
 	for _, worker := range model.LiveWorkers {
 		fmt.Fprintf(
 			writer, "lunchpail.io\tliveworker\t%d\t%d\t%d\t%d\t%s\t%s\t%v\n",
-			len(worker.assignedTasks), len(worker.processingTasks), worker.nSuccess, worker.nFail, worker.name, run, worker.killfilePresent,
+			len(worker.assignedTasks), len(worker.processingTasks), worker.nSuccess, worker.nFail, worker.name, c.Spec.RunName, worker.killfilePresent,
 		)
 	}
 	for _, worker := range model.DeadWorkers {
 		fmt.Fprintf(
 			writer, "lunchpail.io\tdeadworker\t%d\t%d\t%d\t%d\t%s\t%s\n",
-			len(worker.assignedTasks), len(worker.processingTasks), worker.nSuccess, worker.nFail, worker.name, run,
+			len(worker.assignedTasks), len(worker.processingTasks), worker.nSuccess, worker.nFail, worker.name, c.Spec.RunName,
 		)
 	}
 	fmt.Fprintf(writer, "lunchpail.io\t---\n")
@@ -44,7 +43,7 @@ func (model Model) report(c client) error {
 	fmt.Fprintf(os.Stdout, b.String())
 
 	// and write to the log file
-	if err := os.MkdirAll(logDir, 0700); err != nil {
+	/*if err := os.MkdirAll(logDir, 0700); err != nil {
 		return err
 	}
 	logFile := filepath.Join(logDir, "qstat.txt")
@@ -56,5 +55,6 @@ func (model Model) report(c client) error {
 		return err
 	}
 
-	return c.reportChangedFile(logFile)
+	return c.reportChangedFile(logFile)*/
+	return nil
 }


### PR DESCRIPTION
this removes the complex combination of env vars and implicit logic to encode s3 queue paths in favor of passing explicit paths on the command line. this lets us consolidate the logic in the front-end. the runtime only uses the explicit paths as given.

TODO: this only cleans up the workstealer