### PR TITLE
feat: update scheme and layout of queue paths 

### DIFF
--- a/cmd/options/run.go
+++ b/cmd/options/run.go
@@ -17,3 +17,17 @@ func AddRequiredRunOptions(cmd *cobra.Command) *RunOptions {
 	cmd.MarkFlagRequired("run")
 	return opts
 }
+
+type BucketAndRunOptions struct {
+	Run    string
+	Bucket string
+}
+
+func AddBucketAndRunOptions(cmd *cobra.Command) *BucketAndRunOptions {
+	options := BucketAndRunOptions{}
+	cmd.Flags().StringVarP(&options.Run, "run", "r", "", "Inspect the given run, defaulting to using the singleton run")
+	cmd.Flags().StringVar(&options.Bucket, "bucket", "", "Use the given S3 bucket")
+	cmd.MarkFlagRequired("run")
+	cmd.MarkFlagRequired("bucket")
+	return &options
+}

--- a/cmd/subcommands/component/minio/server.go
+++ b/cmd/subcommands/component/minio/server.go
@@ -5,23 +5,30 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"lunchpail.io/cmd/options"
+	"lunchpail.io/pkg/fe/transformer/api"
 	"lunchpail.io/pkg/runtime/minio"
 )
 
 func Server() *cobra.Command {
-	var port int
-
 	cmd := &cobra.Command{
 		Use:   "server",
 		Short: "Run as the minio component",
 		Long:  "Run as the minio component",
 		Args:  cobra.MatchAll(cobra.ExactArgs(0), cobra.OnlyValidArgs),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return minio.Server(context.Background(), port)
-		},
 	}
 
+	var port int
 	cmd.Flags().IntVarP(&port, "port", "p", 9000, "Port to use for the Minio api endpoint")
+
+	runOpts := options.AddBucketAndRunOptions(cmd)
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return minio.Server(context.Background(), port, api.PathArgs{
+			Bucket:  runOpts.Bucket,
+			RunName: runOpts.Run,
+		})
+	}
 
 	return cmd
 }

--- a/cmd/subcommands/component/worker/run.go
+++ b/cmd/subcommands/component/worker/run.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"lunchpail.io/cmd/options"
+	"lunchpail.io/pkg/fe/transformer/api"
 	"lunchpail.io/pkg/runtime/worker"
 )
 
@@ -18,17 +19,19 @@ func Run() *cobra.Command {
 		Args:  cobra.MatchAll(cobra.OnlyValidArgs),
 	}
 
-	var bucket string
-	cmd.Flags().StringVar(&bucket, "bucket", "", "Which S3 bucket to use")
-	cmd.MarkFlagRequired("bucket")
+	runOpts := options.AddBucketAndRunOptions(cmd)
 
-	var alive string
-	cmd.Flags().StringVar(&alive, "alive", "", "Where to place our alive file")
-	cmd.MarkFlagRequired("alive")
+	var step int
+	cmd.Flags().IntVar(&step, "step", 0, "Which step are we part of")
+	cmd.MarkFlagRequired("step")
 
-	var listenPrefix string
-	cmd.Flags().StringVar(&listenPrefix, "listen-prefix", "", "Which S3 listen-prefix to use")
-	cmd.MarkFlagRequired("listen-prefix")
+	var poolName string
+	cmd.Flags().StringVar(&poolName, "pool", "", "Which worker pool are we part of")
+	cmd.MarkFlagRequired("pool")
+
+	var workerName string
+	cmd.Flags().StringVar(&workerName, "worker", "", "Which worker are we")
+	cmd.MarkFlagRequired("worker")
 
 	var pollingInterval int
 	cmd.Flags().IntVar(&pollingInterval, "polling-interval", 3, "If polling is employed, the interval between probes")
@@ -47,10 +50,12 @@ func Run() *cobra.Command {
 			StartupDelay:    startupDelay,
 			PollingInterval: pollingInterval,
 			LogOptions:      *logOpts,
-			Queue: worker.Queue{
-				ListenPrefix: listenPrefix,
-				Bucket:       bucket,
-				Alive:        alive,
+			PathArgs: api.PathArgs{
+				Bucket:     runOpts.Bucket,
+				RunName:    runOpts.Run,
+				Step:       step,
+				PoolName:   poolName,
+				WorkerName: workerName,
 			},
 		})
 	}

--- a/cmd/subcommands/queue/add/file.go
+++ b/cmd/subcommands/queue/add/file.go
@@ -25,15 +25,15 @@ func File() *cobra.Command {
 	cmd.Flags().BoolVar(&ignoreWorkerErrors, "ignore-worker-errors", false, "When --wait, ignore any errors from the workers processing the tasks")
 
 	logOpts := options.AddLogOptions(cmd)
+	runOpts := options.AddRequiredRunOptions(cmd)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		if !opts.Wait && ignoreWorkerErrors {
 			return fmt.Errorf("Invalid combination of options, not --wait and --ignore-worker-errors")
 		}
 
-		opts.Verbose = logOpts.Verbose
-		opts.Debug = logOpts.Debug
-		exitcode, err := queue.Add(context.Background(), args[0], opts)
+		opts.LogOptions = *logOpts
+		exitcode, err := queue.Add(context.Background(), runOpts.Run, args[0], opts)
 
 		switch {
 		case err != nil:

--- a/cmd/subcommands/queue/add/s3.go
+++ b/cmd/subcommands/queue/add/s3.go
@@ -20,18 +20,18 @@ func S3() *cobra.Command {
 
 	var repeat int
 	var opts queue.AddS3Options
-	cmd.Flags().IntVarP(&repeat, "repeat", "r", 1, "Upload N copies of the task")
+	cmd.Flags().IntVar(&repeat, "repeat", 1, "Upload N copies of the task")
 
 	logOpts := options.AddLogOptions(cmd)
+	runOpts := options.AddRequiredRunOptions(cmd)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		envvarPrefix := args[1]
 		endpoint := os.Getenv(envvarPrefix + "endpoint")
 		accessKeyID := os.Getenv(envvarPrefix + "accessKeyID")
 		secretAccessKey := os.Getenv(envvarPrefix + "secretAccessKey")
-		opts.Verbose = logOpts.Verbose
-		opts.Debug = logOpts.Debug
-		return queue.AddFromS3(context.Background(), args[0], endpoint, accessKeyID, secretAccessKey, repeat, opts)
+		opts.LogOptions = *logOpts
+		return queue.AddFromS3(context.Background(), runOpts.Run, args[0], endpoint, accessKeyID, secretAccessKey, repeat, opts)
 	}
 
 	return cmd

--- a/cmd/subcommands/queue/done.go
+++ b/cmd/subcommands/queue/done.go
@@ -17,9 +17,10 @@ func Done() *cobra.Command {
 		Args:  cobra.MatchAll(cobra.OnlyValidArgs),
 	}
 	logOpts := options.AddLogOptions(cmd)
+	runOpts := options.AddRequiredRunOptions(cmd)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		return queue.Qdone(context.Background(), *logOpts)
+		return queue.Qdone(context.Background(), runOpts.Run, *logOpts)
 	}
 
 	return cmd

--- a/cmd/subcommands/queue/ls.go
+++ b/cmd/subcommands/queue/ls.go
@@ -10,6 +10,7 @@ import (
 
 	"lunchpail.io/cmd/options"
 	"lunchpail.io/pkg/be"
+	"lunchpail.io/pkg/be/runs/util"
 	"lunchpail.io/pkg/runtime/queue"
 )
 
@@ -41,7 +42,15 @@ func Ls() *cobra.Command {
 			return err
 		}
 
-		files, errors, err := queue.Ls(ctx, backend, runOpts.Run, path)
+		run := runOpts.Run
+		if run == "" {
+			rrun, err := util.Singleton(ctx, backend)
+			if err != nil {
+				return err
+			}
+			run = rrun.Name
+		}
+		files, errors, err := queue.Ls(ctx, backend, run, path)
 		if err != nil {
 			return err
 		}

--- a/pkg/boot/io.go
+++ b/pkg/boot/io.go
@@ -20,7 +20,7 @@ func catAndRedirect(ctx context.Context, inputs []string, backend be.Backend, ir
 	}
 	defer client.Stop()
 
-	if err := builtins.Cat(ctx, client.S3Client, inputs, opts); err != nil {
+	if err := builtins.Cat(ctx, client.S3Client, ir.RunName, inputs, opts); err != nil {
 		return err
 	}
 
@@ -35,7 +35,7 @@ func catAndRedirect(ctx context.Context, inputs []string, backend be.Backend, ir
 			}
 			return "."
 		}
-		if err := builtins.RedirectTo(ctx, client.S3Client, folderFor, opts); err != nil {
+		if err := builtins.RedirectTo(ctx, client.S3Client, ir.RunName, folderFor, opts); err != nil {
 			return err
 		}
 	}

--- a/pkg/boot/watch.go
+++ b/pkg/boot/watch.go
@@ -7,6 +7,7 @@ import (
 
 	"lunchpail.io/pkg/be"
 	"lunchpail.io/pkg/ir/llir"
+	"lunchpail.io/pkg/lunchpail"
 	"lunchpail.io/pkg/observe"
 	"lunchpail.io/pkg/observe/cpu"
 )
@@ -16,7 +17,12 @@ type WatchOptions struct {
 }
 
 func watchLogs(ctx context.Context, backend be.Backend, ir llir.LLIR, opts WatchOptions) {
-	err := observe.Logs(ctx, ir.RunName, backend, observe.LogsOptions{Follow: true, Verbose: opts.Verbose})
+	components := lunchpail.AllUserComponents
+	if opts.Verbose && os.Getenv("CI") != "" {
+		components = lunchpail.AllComponents
+	}
+
+	err := observe.Logs(ctx, ir.RunName, backend, observe.LogsOptions{Follow: true, Verbose: opts.Verbose, Components: components})
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 	}

--- a/pkg/fe/transformer/api/dispatch/parametersweep/lower.go
+++ b/pkg/fe/transformer/api/dispatch/parametersweep/lower.go
@@ -9,7 +9,7 @@ import (
 )
 
 func Lower(buildName, runname string, sweep hlir.ParameterSweep, ir llir.LLIR, opts build.Options) (llir.Component, error) {
-	app, err := transpile(sweep)
+	app, err := transpile(runname, sweep)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/fe/transformer/api/dispatch/parametersweep/main.sh
+++ b/pkg/fe/transformer/api/dispatch/parametersweep/main.sh
@@ -50,6 +50,6 @@ do
     # If we were asked to wait, then `queue add file` will exit with the
     # exit code of the underlying worker. Here, we intentionally
     # ignore any errors from the task.
-    $LUNCHPAIL_EXE queue add file $task $waitflag $verboseflag $debugflag
+    $LUNCHPAIL_EXE queue add file $task $waitflag $verboseflag $debugflag --run $1
     rm -f "$task"
 done

--- a/pkg/fe/transformer/api/dispatch/parametersweep/transpile.go
+++ b/pkg/fe/transformer/api/dispatch/parametersweep/transpile.go
@@ -10,15 +10,15 @@ import (
 )
 
 // Transpile hlir.ParameterSweep to hlir.Application
-func transpile(sweep hlir.ParameterSweep) (hlir.Application, error) {
+func transpile(runname string, sweep hlir.ParameterSweep) (hlir.Application, error) {
 	app := hlir.NewApplication(sweep.Metadata.Name)
 
 	app.Spec.Image = fmt.Sprintf("%s/%s/lunchpail:%s", lunchpail.ImageRegistry, lunchpail.ImageRepo, lunchpail.Version())
 	app.Spec.Role = "dispatcher"
 
 	app.Spec.Command = strings.Join([]string{
-		`trap "$LUNCHPAIL_EXE queue done" EXIT`,
-		"./main.sh",
+		fmt.Sprintf(`trap "$LUNCHPAIL_EXE queue done --run %s" EXIT`, runname),
+		fmt.Sprintf("./main.sh %s", runname),
 	}, "\n")
 
 	app.Spec.Code = []hlir.Code{

--- a/pkg/fe/transformer/api/dispatch/s3/lower.go
+++ b/pkg/fe/transformer/api/dispatch/s3/lower.go
@@ -9,7 +9,7 @@ import (
 )
 
 func Lower(buildName, runname string, s3 hlir.ProcessS3Objects, ir llir.LLIR, opts build.Options) (llir.Component, error) {
-	app, err := transpile(s3)
+	app, err := transpile(runname, s3)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/fe/transformer/api/dispatch/s3/transpile.go
+++ b/pkg/fe/transformer/api/dispatch/s3/transpile.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Transpile hlir.ProcessS3Objects to hlir.Application
-func transpile(s3 hlir.ProcessS3Objects) (hlir.Application, error) {
+func transpile(runname string, s3 hlir.ProcessS3Objects) (hlir.Application, error) {
 	app := hlir.NewApplication(s3.Metadata.Name)
 
 	if s3.Spec.Rclone.RemoteName == "" {
@@ -39,8 +39,8 @@ func transpile(s3 hlir.ProcessS3Objects) (hlir.Application, error) {
 
 	envPrefix := "LUNCHPAIL_PROCESS_S3_OBJECTS_"
 	app.Spec.Command = strings.Join([]string{
-		`trap "$LUNCHPAIL_EXE queue done" EXIT`,
-		fmt.Sprintf("$LUNCHPAIL_EXE queue add s3 --repeat %d %s %s %s %s", repeat, verbose, debug, s3.Spec.Path, envPrefix),
+		fmt.Sprintf(`trap "$LUNCHPAIL_EXE queue done --run %s" EXIT`, runname),
+		fmt.Sprintf("$LUNCHPAIL_EXE queue add s3 --run %s --repeat %d %s %s %s %s", runname, repeat, verbose, debug, s3.Spec.Path, envPrefix),
 	}, "\n")
 
 	app.Spec.Env = hlir.Env{}

--- a/pkg/fe/transformer/api/minio/transpile.go
+++ b/pkg/fe/transformer/api/minio/transpile.go
@@ -3,10 +3,7 @@ package minio
 import (
 	"fmt"
 	"os"
-	"path/filepath"
-	"strings"
 
-	"lunchpail.io/pkg/fe/transformer/api"
 	"lunchpail.io/pkg/ir/hlir"
 	"lunchpail.io/pkg/ir/llir"
 )
@@ -18,18 +15,13 @@ func transpile(runname string, ir llir.LLIR) (hlir.Application, error) {
 	app.Spec.Image = "docker.io/minio/minio:RELEASE.2024-07-04T14-25-45Z"
 	app.Spec.Role = "queue"
 	app.Spec.Expose = []string{fmt.Sprintf("%d:%d", ir.Queue.Port, ir.Queue.Port)}
-	app.Spec.Command = fmt.Sprintf("$LUNCHPAIL_EXE component minio server --port %d", ir.Queue.Port)
+	app.Spec.Command = fmt.Sprintf("$LUNCHPAIL_EXE component minio server --port %d --bucket %s --run %s", ir.Queue.Port, ir.Queue.Bucket, runname)
 
 	/*app.Spec.Needs = []hlir.Needs{
 	{Name: "minio", Version: "latest"}}*/
-	prefixIncludingBucket := api.QueuePrefixPath(ir.Queue, runname)
-	A := strings.Split(prefixIncludingBucket, "/")
-	prefixExcludingBucket := filepath.Join(A[1:]...)
 
 	app.Spec.Env = hlir.Env{}
 	app.Spec.Env["USE_MINIO_EXTENSIONS"] = "true"
-	app.Spec.Env["LUNCHPAIL_QUEUE_BUCKET"] = ir.Queue.Bucket
-	app.Spec.Env["LUNCHPAIL_QUEUE_PREFIX"] = prefixExcludingBucket
 
 	// This can help with tests
 	app.Spec.Env["LUNCHPAIL_SLEEP_BEFORE_EXIT"] = os.Getenv("LUNCHPAIL_SLEEP_BEFORE_EXIT")

--- a/pkg/fe/transformer/api/shell/lower.go
+++ b/pkg/fe/transformer/api/shell/lower.go
@@ -37,6 +37,11 @@ func LowerAsComponent(buildName, runname string, app hlir.Application, ir llir.L
 		component.InstanceName = runname
 	}
 
+	if app.Spec.Env == nil {
+		app.Spec.Env = hlir.Env{}
+	}
+	app.Spec.Env["LUNCHPAIL_RUN"] = runname
+
 	for _, needs := range app.Spec.Needs {
 		var file *os.File
 		var err error

--- a/pkg/fe/transformer/api/workstealer/transpile.go
+++ b/pkg/fe/transformer/api/workstealer/transpile.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"lunchpail.io/pkg/build"
-	"lunchpail.io/pkg/fe/transformer/api"
 	"lunchpail.io/pkg/ir/hlir"
 	"lunchpail.io/pkg/ir/llir"
 	"lunchpail.io/pkg/lunchpail"
@@ -13,11 +12,18 @@ import (
 
 // Transpile workstealer to hlir.Application
 func transpile(runname string, ir llir.LLIR, opts build.LogOptions) (hlir.Application, error) {
+	step := 0 // TODO
 	app := hlir.NewApplication(runname + "-workstealer")
 
 	app.Spec.Image = fmt.Sprintf("%s/%s/lunchpail:%s", lunchpail.ImageRegistry, lunchpail.ImageRepo, lunchpail.Version())
 	app.Spec.Role = "workstealer"
-	app.Spec.Command = fmt.Sprintf("$LUNCHPAIL_EXE component workstealer run --verbose=%v --debug=%v --run %s --bucket %s --listen-prefix %s --unassigned %s --outbox %s --finished %s --worker-inbox-base %s --worker-processing-base %s --worker-outbox-base %s --worker-killfile-base %s --all-done %s", opts.Verbose, opts.Debug, runname, ir.Queue.Bucket, api.QueuePrefixPath0(ir.Queue, runname), api.UnassignedPath(ir.Queue, runname), api.OutboxPath(ir.Queue, runname), api.FinishedPath(ir.Queue, runname), api.WorkerInboxPathBase(ir.Queue, runname), api.WorkerProcessingPathBase(ir.Queue, runname), api.WorkerOutboxPathBase(ir.Queue, runname), api.WorkerKillfilePathBase(ir.Queue, runname), api.AllDone(ir.Queue, runname))
+	app.Spec.Command = fmt.Sprintf("$LUNCHPAIL_EXE component workstealer run --verbose=%v --debug=%v --bucket %s --run %s --step %d",
+		opts.Verbose,
+		opts.Debug,
+		ir.Queue.Bucket,
+		runname,
+		step,
+	)
 
 	app.Spec.Env = hlir.Env{}
 	app.Spec.Env["LUNCHPAIL_RUN_NAME"] = runname

--- a/pkg/lunchpail/component.go
+++ b/pkg/lunchpail/component.go
@@ -12,6 +12,7 @@ const (
 )
 
 var AllUserComponents = []Component{WorkersComponent, DispatcherComponent}
+var AllComponents = []Component{WorkersComponent, DispatcherComponent, WorkStealerComponent, MinioComponent}
 
 func ComponentShortName(c Component) string {
 	switch c {

--- a/pkg/runtime/builtins/cat.go
+++ b/pkg/runtime/builtins/cat.go
@@ -9,16 +9,16 @@ import (
 	"lunchpail.io/pkg/runtime/queue"
 )
 
-func Cat(ctx context.Context, client queue.S3Client, inputs []string, opts build.LogOptions) error {
+func Cat(ctx context.Context, client queue.S3Client, runname string, inputs []string, opts build.LogOptions) error {
 	qopts := queue.AddOptions{
 		S3Client:   client,
 		LogOptions: opts,
 	}
-	if err := queue.AddList(ctx, inputs, qopts); err != nil {
+	if err := queue.AddList(ctx, runname, inputs, qopts); err != nil {
 		return err
 	}
 
-	if err := queue.QdoneClient(ctx, client, opts); err != nil {
+	if err := queue.QdoneClient(ctx, client, runname, opts); err != nil {
 		return err
 	}
 
@@ -32,7 +32,7 @@ func CatClient(ctx context.Context, backend be.Backend, runname string, inputs [
 	}
 	defer client.Stop()
 
-	return Cat(ctx, client.S3Client, inputs, opts)
+	return Cat(ctx, client.S3Client, runname, inputs, opts)
 }
 
 func CatApp() hlir.HLIR {

--- a/pkg/runtime/queue/drain.go
+++ b/pkg/runtime/queue/drain.go
@@ -6,6 +6,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"lunchpail.io/pkg/be"
+	"lunchpail.io/pkg/fe/transformer/api"
 )
 
 // Drain the output tasks, allowing graceful termination
@@ -16,13 +17,16 @@ func Drain(ctx context.Context, backend be.Backend, runname string) error {
 	}
 	defer c.Stop()
 
+	args := api.PathArgs{Bucket: c.Paths.Bucket, RunName: runname, Step: 0} // FIXME
+	outbox := args.TemplateP(api.AssignedAndFinished)
+
 	group, _ := errgroup.WithContext(ctx)
-	for o := range c.ListObjects(c.Paths.Bucket, c.finishedMarkers(), true) {
+	for o := range c.ListObjects(args.Bucket, outbox, true) {
 		if o.Err != nil {
 			return o.Err
 		}
 
-		group.Go(func() error { return c.MarkConsumed(o.Key) })
+		group.Go(func() error { return c.Rm(args.Bucket, o.Key) })
 	}
 
 	return group.Wait()

--- a/pkg/runtime/queue/ls.go
+++ b/pkg/runtime/queue/ls.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"lunchpail.io/pkg/be"
+	"lunchpail.io/pkg/fe/transformer/api"
 )
 
 func Ls(ctx context.Context, backend be.Backend, runname, path string) (<-chan string, <-chan error, error) {
@@ -16,7 +17,9 @@ func Ls(ctx context.Context, backend be.Backend, runname, path string) (<-chan s
 
 	files := make(chan string)
 	errors := make(chan error)
-	prefix := filepath.Join(c.Paths.Prefix, path)
+
+	args := api.PathArgs{Bucket: c.Paths.Bucket, RunName: runname, Step: 0}
+	prefix := filepath.Join(args.ListenPrefix(), path)
 
 	go func() {
 		defer c.Stop()

--- a/pkg/runtime/queue/paths.go
+++ b/pkg/runtime/queue/paths.go
@@ -2,7 +2,6 @@ package queue
 
 import (
 	"os"
-	"path/filepath"
 	"strings"
 )
 
@@ -12,15 +11,7 @@ const (
 )
 
 type filepaths struct {
-	Bucket     string
-	PoolPrefix string
-	Prefix     string
-	Inbox      string
-	Processing string
-	Outbox     string
-
-	// Dispatcher is done
-	Done string
+	Bucket string
 }
 
 func pathsForRun() (filepaths, error) {
@@ -30,24 +21,6 @@ func pathsForRun() (filepaths, error) {
 func pathsFor(queuePrefixPath string) (filepaths, error) {
 	fullPrefix := strings.Split(queuePrefixPath, "/")
 	bucket := fullPrefix[0]
-	poolPrefix := filepath.Join(fullPrefix[1:]...)
-	prefix := strings.Replace(filepath.Join(fullPrefix[1:]...), "$LUNCHPAIL_WORKER_NAME", os.Getenv("LUNCHPAIL_POD_NAME"), 1)
-	inbox := inboxFolder
-	processing := "processing"
-	outbox := outboxFolder
-	done := filepath.Join(poolPrefix, "done")
 
-	return filepaths{bucket, poolPrefix, prefix, inbox, processing, outbox, done}, nil
-}
-
-func (c S3Client) Outbox() string {
-	return filepath.Join(c.Paths.PoolPrefix, c.Paths.Outbox)
-}
-
-func (c S3Client) finishedMarkers() string {
-	return filepath.Join(c.Paths.PoolPrefix, "finished")
-}
-
-func (c S3Client) ConsumedMarker(task string) string {
-	return filepath.Join(c.Paths.PoolPrefix, "consumed", filepath.Base(task))
+	return filepaths{bucket}, nil
 }

--- a/pkg/runtime/queue/qcat.go
+++ b/pkg/runtime/queue/qcat.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"lunchpail.io/pkg/be"
+	"lunchpail.io/pkg/fe/transformer/api"
 )
 
 func Qcat(ctx context.Context, backend be.Backend, runname, path string) error {
@@ -14,8 +15,10 @@ func Qcat(ctx context.Context, backend be.Backend, runname, path string) error {
 	}
 	defer c.Stop()
 
-	prefix := filepath.Join(c.Paths.Prefix, path)
-	if err := c.Cat(c.Paths.Bucket, prefix); err != nil {
+	args := api.PathArgs{Bucket: c.Paths.Bucket, RunName: runname, Step: 0} // FIXME
+	fullPath := filepath.Join(args.ListenPrefix(), path)
+
+	if err := c.Cat(args.Bucket, fullPath); err != nil {
 		return err
 	}
 

--- a/pkg/runtime/queue/qdone.go
+++ b/pkg/runtime/queue/qdone.go
@@ -6,22 +6,25 @@ import (
 	"os"
 
 	"lunchpail.io/pkg/build"
+	"lunchpail.io/pkg/fe/transformer/api"
 )
 
 // Indicate dispatching is done, with given client
-func QdoneClient(ctx context.Context, c S3Client, opts build.LogOptions) (err error) {
+func QdoneClient(ctx context.Context, c S3Client, runname string, opts build.LogOptions) (err error) {
 	if opts.Verbose {
 		fmt.Fprintf(os.Stderr, "Done with dispatching\n")
 	}
-	return c.Touch(c.Paths.Bucket, c.Paths.Done)
+
+	args := api.PathArgs{Bucket: c.Paths.Bucket, RunName: runname, Step: 0} // FIXME
+	return c.Touch(args.Bucket, args.TemplateP(api.DispatcherDoneMarker))
 }
 
 // Indicate dispatching is done
-func Qdone(ctx context.Context, opts build.LogOptions) error {
+func Qdone(ctx context.Context, runname string, opts build.LogOptions) error {
 	c, err := NewS3Client(ctx) // pull config from env vars
 	if err != nil {
 		return err
 	}
 
-	return QdoneClient(ctx, c, opts)
+	return QdoneClient(ctx, c, runname, opts)
 }

--- a/pkg/runtime/queue/s3.go
+++ b/pkg/runtime/queue/s3.go
@@ -183,10 +183,6 @@ func (s3 S3Client) Rm(bucket, filePath string) error {
 	return s3.client.RemoveObject(s3.context, bucket, filePath, minio.RemoveObjectOptions{})
 }
 
-func (s3 S3Client) MarkConsumed(filePath string) error {
-	return s3.Mark(s3.Paths.Bucket, s3.ConsumedMarker(filePath), "consumed")
-}
-
 func (s3 S3Client) Mark(bucket, filePath, marker string) error {
 	_, err := s3.client.PutObject(s3.context, bucket, filePath, strings.NewReader(marker), int64(len(marker)), minio.PutObjectOptions{})
 	return err

--- a/pkg/runtime/worker/options.go
+++ b/pkg/runtime/worker/options.go
@@ -1,16 +1,12 @@
 package worker
 
-import "lunchpail.io/pkg/build"
-
-type Queue struct {
-	Bucket       string
-	ListenPrefix string
-	Alive        string
-	Dead         string
-}
+import (
+	"lunchpail.io/pkg/build"
+	"lunchpail.io/pkg/fe/transformer/api"
+)
 
 type Options struct {
-	Queue
+	api.PathArgs
 	StartupDelay    int
 	PollingInterval int
 	build.LogOptions

--- a/pkg/runtime/worker/prestop.go
+++ b/pkg/runtime/worker/prestop.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"lunchpail.io/pkg/fe/transformer/api"
 	"lunchpail.io/pkg/runtime/queue"
 )
 
@@ -18,8 +19,8 @@ func PreStop(ctx context.Context, opts Options) error {
 		fmt.Println("Marking worker as done...")
 	}
 
-	client.Rm(opts.Bucket, opts.Alive)
-	client.Touch(opts.Bucket, opts.Dead)
+	client.Rm(opts.PathArgs.Bucket, opts.PathArgs.TemplateP(api.WorkerAliveMarker))
+	client.Touch(opts.PathArgs.Bucket, opts.PathArgs.TemplateP(api.WorkerDeadMarker))
 
 	if opts.LogOptions.Verbose {
 		fmt.Printf("This worker is shutting down %s\n", os.Getenv("LUNCHPAIL_POD_NAME"))

--- a/pkg/runtime/worker/process-task.go
+++ b/pkg/runtime/worker/process-task.go
@@ -1,0 +1,148 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+
+	"golang.org/x/sync/errgroup"
+
+	"lunchpail.io/pkg/fe/transformer/api"
+	"lunchpail.io/pkg/runtime/queue"
+)
+
+type taskProcessor struct {
+	ctx               context.Context
+	client            queue.S3Client
+	handler           []string
+	localdir          string
+	opts              Options
+	backgroundS3Tasks *errgroup.Group
+}
+
+// Process one task by invoking the given `handler` command line on
+// the given `task` (stored in S3, in the inbox for this worker)
+func (p taskProcessor) process(task string) error {
+	opts := p.opts
+	client := p.client
+
+	if task != "" {
+		task = filepath.Base(task)
+
+		if opts.LogOptions.Verbose {
+			fmt.Fprintf(os.Stderr, "Worker starting task %s\n", task)
+		}
+
+		a := opts.PathArgs.ForTask(task)
+		in := a.TemplateP(api.AssignedAndPending)
+		inprogress := a.TemplateP(api.AssignedAndProcessing)
+		out := a.TemplateP(api.AssignedAndFinished)
+		ec := a.TemplateP(api.FinishedWithCode)
+		failed := a.TemplateP(api.FinishedWithFailed)
+		succeeded := a.TemplateP(api.FinishedWithSucceeded)
+		stdout := a.TemplateP(api.FinishedWithStdout)
+		stderr := a.TemplateP(api.FinishedWithStderr)
+
+		localprocessing := filepath.Join(p.localdir, task)
+		localoutbox := filepath.Join(p.localdir, "outbox", task)
+		localstdout := localprocessing + ".stdout"
+		localstderr := localprocessing + ".stderr"
+
+		// Currently, we don't need localoutbox to be a
+		// directory. This is future-proofing for handling
+		// multiple outputs from the handler. #398
+		err := os.MkdirAll(filepath.Dir(localoutbox), os.ModePerm)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "Internal Error creating local outbox:", err)
+			return nil
+		}
+
+		err = client.Download(opts.PathArgs.Bucket, in, localprocessing)
+		if err != nil {
+			if !strings.Contains(err.Error(), "key does not exist") {
+				// we ignore "key does not exist" errors, as these result from the work
+				// we thought we were assigned having been stolen by the workstealer
+				fmt.Fprintf(os.Stderr, "Internal Error copying task to worker processing %s %s->%s: %v\n", opts.PathArgs.Bucket, in, localprocessing, err)
+			}
+			return nil
+		}
+
+		doneMovingToProcessing := make(chan struct{})
+		go func() {
+			if client.Moveto(opts.PathArgs.Bucket, in, inprogress) != nil {
+				fmt.Fprintf(os.Stderr, "Internal Error moving task to processing %s->%s: %v\n", in, inprogress, err)
+			}
+			doneMovingToProcessing <- struct{}{}
+		}()
+
+		// open stdout/err files for writing
+		stdoutfile, err := os.Create(localstdout)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "Internal Error creating stdout file:", err)
+			return nil
+		}
+		defer stdoutfile.Close()
+
+		stderrfile, err := os.Create(localstderr)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "Internal Error creating stderr file:", err)
+			return nil
+		}
+		defer stderrfile.Close()
+
+		handlercmd := exec.CommandContext(p.ctx, p.handler[0], slices.Concat(p.handler[1:], []string{localprocessing, localoutbox})...)
+		handlercmd.Stdout = io.MultiWriter(os.Stdout, stdoutfile)
+		handlercmd.Stderr = io.MultiWriter(os.Stderr, stderrfile)
+		err = handlercmd.Run()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "Internal Error running the handler:", err)
+			stderrfile.Write([]byte(err.Error()))
+		}
+
+		exitCode := handlercmd.ProcessState.ExitCode()
+
+		p.backgroundS3Tasks.Go(func() error { return client.Mark(opts.PathArgs.Bucket, ec, strconv.Itoa(exitCode)) })
+		p.backgroundS3Tasks.Go(func() error { return client.Upload(opts.PathArgs.Bucket, localstdout, stdout) })
+		p.backgroundS3Tasks.Go(func() error { return client.Upload(opts.PathArgs.Bucket, localstderr, stderr) })
+		if exitCode == 0 {
+			if opts.LogOptions.Debug {
+				fmt.Fprintf(os.Stderr, "Succeeded on task %s\n", localprocessing)
+			}
+			p.backgroundS3Tasks.Go(func() error { return client.Touch(opts.PathArgs.Bucket, succeeded) })
+		} else {
+			fmt.Fprintln(os.Stderr, "Error with exit code "+strconv.Itoa(exitCode)+" while processing "+filepath.Base(in))
+			p.backgroundS3Tasks.Go(func() error { return client.Touch(opts.PathArgs.Bucket, failed) })
+		}
+
+		if _, err := os.Stat(localoutbox); err == nil {
+			if opts.LogOptions.Verbose {
+				fmt.Fprintf(os.Stderr, "Uploading worker-produced outbox file %s->%s\n", localoutbox, out)
+			}
+			p.backgroundS3Tasks.Go(func() error { return client.Upload(opts.PathArgs.Bucket, localoutbox, out) })
+			p.backgroundS3Tasks.Go(func() error {
+				<-doneMovingToProcessing
+				return client.Rm(opts.PathArgs.Bucket, inprogress)
+			})
+		} else {
+			if opts.LogOptions.Verbose {
+				fmt.Fprintf(os.Stderr, "Moving input to outbox file %s->%s\n", inprogress, out)
+			}
+			p.backgroundS3Tasks.Go(func() error {
+				<-doneMovingToProcessing
+				return client.Moveto(opts.PathArgs.Bucket, inprogress, out)
+			})
+		}
+
+		if opts.LogOptions.Verbose {
+			fmt.Fprintf(os.Stderr, "Worker done with task %s\n", task)
+		}
+	}
+
+	return nil
+}

--- a/pkg/runtime/worker/run.go
+++ b/pkg/runtime/worker/run.go
@@ -17,7 +17,7 @@ func printenv() {
 
 func Run(ctx context.Context, handler []string, opts Options) error {
 	if opts.LogOptions.Verbose {
-		fmt.Fprintf(os.Stderr, "Lunchpail worker starting up\n")
+		fmt.Fprintf(os.Stderr, "Worker starting up\n")
 		printenv()
 	}
 
@@ -27,6 +27,9 @@ func Run(ctx context.Context, handler []string, opts Options) error {
 	}
 
 	if opts.StartupDelay > 0 {
+		if opts.LogOptions.Verbose {
+			fmt.Fprintf(os.Stderr, "Worker delaying for %d seconds\n", opts.StartupDelay)
+		}
 		time.Sleep(time.Duration(opts.StartupDelay) * time.Second)
 	}
 

--- a/pkg/runtime/workstealer/fetch.go
+++ b/pkg/runtime/workstealer/fetch.go
@@ -4,7 +4,6 @@ import (
 	"cmp"
 	"fmt"
 	"os"
-	"regexp"
 	"slices"
 )
 
@@ -22,8 +21,6 @@ type WhatChanged int
 const (
 	UnassignedTask WhatChanged = iota
 	DispatcherDone
-	ConsumedTask
-	FinishedTask
 
 	LiveWorker
 	DeadWorker
@@ -31,121 +28,142 @@ const (
 	KillFileForWorker
 	AssignedTaskByWorker
 	ProcessingTaskByWorker
+	OutboxTaskByWorker
 	SuccessfulTaskByWorker
 	FailedTaskByWorker
 
 	Nothing
 )
 
-var unassignedTaskPattern = regexp.MustCompile("^inbox/(.+)$")
-var dispatcherDonePattern = regexp.MustCompile("^done$")
-var consumedTaskPattern = regexp.MustCompile("^consumed/(.+)$")
-var finishedTaskPattern = regexp.MustCompile("^finished/(.+)$")
-var liveWorkerPattern = regexp.MustCompile("^queues/(.+)/inbox/[.]alive$")
-var deadWorkerPattern = regexp.MustCompile("^queues/(.+)/inbox/[.]dead$")
-var killfilePattern = regexp.MustCompile("^queues/(.+)/kill$")
-var assignedTaskPattern = regexp.MustCompile("^queues/(.+)/inbox/(.+)$")
-var processingTaskPattern = regexp.MustCompile("^queues/(.+)/processing/(.+)$")
-var completedTaskPattern = regexp.MustCompile("^queues/(.+)/outbox/(.+)[.](succeeded|failed)$")
-
 // Determine from a changed line the nature of `WhatChanged`
-func (m *Model) whatChanged(line string) (WhatChanged, string, string) {
-	if match := unassignedTaskPattern.FindStringSubmatch(line); len(match) == 2 {
-		return UnassignedTask, match[1], ""
-	} else if match := dispatcherDonePattern.FindStringSubmatch(line); len(match) == 1 {
-		return DispatcherDone, "", ""
-	} else if match := consumedTaskPattern.FindStringSubmatch(line); len(match) == 2 {
-		return ConsumedTask, match[1], ""
-	} else if match := finishedTaskPattern.FindStringSubmatch(line); len(match) == 2 {
-		return FinishedTask, match[1], ""
-	} else if match := liveWorkerPattern.FindStringSubmatch(line); len(match) == 2 {
-		return LiveWorker, match[1], ""
-	} else if match := deadWorkerPattern.FindStringSubmatch(line); len(match) == 2 {
-		return DeadWorker, match[1], ""
-	} else if match := killfilePattern.FindStringSubmatch(line); len(match) == 2 {
-		return KillFileForWorker, match[1], ""
-	} else if match := assignedTaskPattern.FindStringSubmatch(line); len(match) == 3 {
-		return AssignedTaskByWorker, match[1], match[2]
-	} else if match := processingTaskPattern.FindStringSubmatch(line); len(match) == 3 {
-		return ProcessingTaskByWorker, match[1], match[2]
-	} else if match := completedTaskPattern.FindStringSubmatch(line); len(match) == 4 {
-		if match[3] == "succeeded" {
-			return SuccessfulTaskByWorker, match[1], match[2]
-		} else {
-			return FailedTaskByWorker, match[1], match[2]
-		}
+func (m *Model) whatChanged(line string, patterns pathPatterns) (what WhatChanged, pool string, worker string, task string) {
+	what = Nothing
+
+	if match := patterns.unassignedTask.FindStringSubmatch(line); len(match) == 2 {
+		what = UnassignedTask
+		task = match[1]
+	} else if match := patterns.dispatcherDone.FindStringSubmatch(line); len(match) == 1 {
+		what = DispatcherDone
+	} else if match := patterns.liveWorker.FindStringSubmatch(line); len(match) == 3 {
+		what = LiveWorker
+		pool = match[1]
+		worker = match[2]
+	} else if match := patterns.deadWorker.FindStringSubmatch(line); len(match) == 3 {
+		what = DeadWorker
+		pool = match[1]
+		worker = match[2]
+	} else if match := patterns.killfile.FindStringSubmatch(line); len(match) == 3 {
+		what = KillFileForWorker
+		pool = match[1]
+		worker = match[2]
+	} else if match := patterns.assignedTask.FindStringSubmatch(line); len(match) == 4 {
+		what = AssignedTaskByWorker
+		pool = match[1]
+		worker = match[2]
+		task = match[3]
+	} else if match := patterns.processingTask.FindStringSubmatch(line); len(match) == 4 {
+		what = ProcessingTaskByWorker
+		pool = match[1]
+		worker = match[2]
+		task = match[3]
+	} else if match := patterns.outboxTask.FindStringSubmatch(line); len(match) == 4 {
+		what = OutboxTaskByWorker
+		pool = match[1]
+		worker = match[2]
+		task = match[3]
+	} else if match := patterns.succeededTask.FindStringSubmatch(line); len(match) == 4 {
+		what = SuccessfulTaskByWorker
+		pool = match[1]
+		worker = match[2]
+		task = match[3]
+	} else if match := patterns.failedTask.FindStringSubmatch(line); len(match) == 4 {
+		what = FailedTaskByWorker
+		pool = match[1]
+		worker = match[2]
+		task = match[3]
 	}
 
-	return Nothing, "", ""
+	return
+}
+
+func key(pool, worker string) string {
+	return pool + "/" + worker
 }
 
 // We will be passed a stream of diffs
-func (m *Model) update(filepath string, workersLookup map[string]Worker) {
-	what, thing, thing2 := m.whatChanged(filepath)
+func (m *Model) update(filepath string, workersLookup map[string]*Worker, patterns pathPatterns) {
+	what, pool, worker, task := m.whatChanged(filepath, patterns)
+	k := key(pool, worker)
 
 	switch what {
 	case UnassignedTask:
-		m.UnassignedTasks = append(m.UnassignedTasks, thing)
+		m.UnassignedTasks = append(m.UnassignedTasks, task)
 	case DispatcherDone:
 		m.DispatcherDone = true
-	case ConsumedTask:
-		m.ConsumedTasks = append(m.ConsumedTasks, thing)
-	case FinishedTask:
-		m.FinishedTasks = append(m.FinishedTasks, thing)
 	case LiveWorker:
-		worker := Worker{true, 0, 0, thing, []string{}, []string{}, false}
-		workersLookup[thing] = worker
+		w, ok := workersLookup[k]
+		if !ok {
+			w = &Worker{pool: pool, name: worker}
+			workersLookup[k] = w
+		}
+		w.alive = true
 	case DeadWorker:
-		worker := Worker{false, 0, 0, thing, []string{}, []string{}, false}
-		workersLookup[thing] = worker
+		w, ok := workersLookup[k]
+		if !ok {
+			w = &Worker{pool: pool, name: worker}
+			workersLookup[k] = w
+		}
+		w.alive = false
 	case KillFileForWorker:
-		// thing is worker name
-		if worker, ok := workersLookup[thing]; ok {
-			workersLookup[thing] = Worker{worker.alive, worker.nSuccess, worker.nFail, worker.name, worker.assignedTasks, worker.processingTasks, true}
-		} else {
-			fmt.Fprintf(os.Stderr, "ERROR unable to find worker=%s\n", thing)
+		w, ok := workersLookup[k]
+		if !ok {
+			w = &Worker{pool: pool, name: worker}
+			workersLookup[k] = w
 		}
+		w.killfilePresent = true
 	case AssignedTaskByWorker:
-		// thing is worker name, thing2 is task name
-		m.AssignedTasks = append(m.AssignedTasks, AssignedTask{thing, thing2})
-		if worker, ok := workersLookup[thing]; ok {
-			workersLookup[thing] = Worker{worker.alive, worker.nSuccess, worker.nFail, worker.name, append(worker.assignedTasks, thing2), worker.processingTasks, worker.killfilePresent}
-		} else {
-			fmt.Fprintf(os.Stderr, "ERROR Unable to find worker=%s\n", thing)
+		m.AssignedTasks = append(m.AssignedTasks, AssignedTask{pool, worker, task})
+		w, ok := workersLookup[k]
+		if !ok {
+			w = &Worker{pool: pool, name: worker}
+			workersLookup[k] = w
 		}
+		w.assignedTasks = append(w.assignedTasks, task)
 	case ProcessingTaskByWorker:
-		// thing is worker name, thing2 is task name
-		m.ProcessingTasks = append(m.ProcessingTasks, AssignedTask{thing, thing2})
-		if worker, ok := workersLookup[thing]; ok {
-			workersLookup[thing] = Worker{worker.alive, worker.nSuccess, worker.nFail, worker.name, worker.assignedTasks, append(worker.processingTasks, thing2), worker.killfilePresent}
-		} else {
-			fmt.Fprintf(os.Stderr, "ERROR unable to find worker=%s\n", thing)
+		m.ProcessingTasks = append(m.ProcessingTasks, AssignedTask{pool, worker, task})
+		w, ok := workersLookup[k]
+		if !ok {
+			w = &Worker{pool: pool, name: worker}
+			workersLookup[k] = w
 		}
+		w.processingTasks = append(w.processingTasks, task)
+	case OutboxTaskByWorker:
+		m.OutboxTasks = append(m.OutboxTasks, AssignedTask{pool, worker, task})
 	case SuccessfulTaskByWorker:
-		// thing is worker name, thing2 is task name
-		m.SuccessfulTasks = append(m.SuccessfulTasks, AssignedTask{thing, thing2})
-		if worker, ok := workersLookup[thing]; ok {
-			workersLookup[thing] = Worker{worker.alive, worker.nSuccess + 1, worker.nFail, worker.name, worker.assignedTasks, worker.processingTasks, worker.killfilePresent}
-		} else {
-			fmt.Fprintf(os.Stderr, "ERROR unable to find worker=%s\n", thing)
+		m.SuccessfulTasks = append(m.SuccessfulTasks, AssignedTask{pool, worker, task})
+		w, ok := workersLookup[k]
+		if !ok {
+			w = &Worker{pool: pool, name: worker}
+			workersLookup[k] = w
 		}
+		w.nSuccess++
 	case FailedTaskByWorker:
-		// thing is worker name, thing2 is task name
-		m.FailedTasks = append(m.FailedTasks, AssignedTask{thing, thing2})
-		if worker, ok := workersLookup[thing]; ok {
-			workersLookup[thing] = Worker{worker.alive, worker.nSuccess, worker.nFail + 1, worker.name, worker.assignedTasks, worker.processingTasks, worker.killfilePresent}
-		} else {
-			fmt.Fprintf(os.Stderr, "ERROR unable to find worker=%s\n", thing)
+		m.FailedTasks = append(m.FailedTasks, AssignedTask{pool, worker, task})
+		w, ok := workersLookup[k]
+		if !ok {
+			w = &Worker{pool: pool, name: worker}
+			workersLookup[k] = w
 		}
+		w.nFail++
 	}
 }
 
-func (m *Model) finishUp(workersLookup map[string]Worker) {
+func (m *Model) finishUp(workersLookup map[string]*Worker) {
 	for _, worker := range workersLookup {
 		if worker.alive {
-			m.LiveWorkers = append(m.LiveWorkers, worker)
+			m.LiveWorkers = append(m.LiveWorkers, *worker)
 		} else {
-			m.DeadWorkers = append(m.DeadWorkers, worker)
+			m.DeadWorkers = append(m.DeadWorkers, *worker)
 		}
 	}
 
@@ -160,18 +178,13 @@ func (m *Model) finishUp(workersLookup map[string]Worker) {
 // Return a model of the world
 func (c client) fetchModel() Model {
 	var m Model
-	workersLookup := make(map[string]Worker)
+	workersLookup := make(map[string]*Worker)
 
-	// we will strip off the queue path prefix below
-	l := len(c.Spec.ListenPrefix + "/")
-
-	for o := range c.s3.ListObjects(c.Spec.Bucket, c.Spec.ListenPrefix, true) {
-		if len(o.Key) > l {
-			if c.LogOptions.Debug {
-				fmt.Fprintf(os.Stderr, "Updating model for: %s\n", o.Key[l:])
-			}
-			m.update(o.Key[l:], workersLookup)
+	for o := range c.s3.ListObjects(c.PathArgs.Bucket, c.PathArgs.ListenPrefix(), true) {
+		if c.LogOptions.Debug {
+			fmt.Fprintf(os.Stderr, "Updating model for: %s\n", o.Key)
 		}
+		m.update(o.Key, workersLookup, c.pathPatterns)
 	}
 
 	m.finishUp(workersLookup)

--- a/pkg/runtime/workstealer/patterns.go
+++ b/pkg/runtime/workstealer/patterns.go
@@ -1,0 +1,35 @@
+package workstealer
+
+import (
+	"regexp"
+
+	"lunchpail.io/pkg/fe/transformer/api"
+)
+
+type pathPatterns struct {
+	liveWorker     *regexp.Regexp
+	deadWorker     *regexp.Regexp
+	killfile       *regexp.Regexp
+	unassignedTask *regexp.Regexp
+	assignedTask   *regexp.Regexp
+	processingTask *regexp.Regexp
+	outboxTask     *regexp.Regexp
+	succeededTask  *regexp.Regexp
+	failedTask     *regexp.Regexp
+	dispatcherDone *regexp.Regexp
+}
+
+func newPathPatterns(a api.PathArgs) pathPatterns {
+	return pathPatterns{
+		liveWorker:     a.PatternFor(api.WorkerAliveMarker),
+		deadWorker:     a.PatternFor(api.WorkerDeadMarker),
+		killfile:       a.PatternFor(api.WorkerKillFile),
+		unassignedTask: a.PatternFor(api.Unassigned),
+		assignedTask:   a.PatternFor(api.AssignedAndPending),
+		processingTask: a.PatternFor(api.AssignedAndProcessing),
+		outboxTask:     a.PatternFor(api.AssignedAndFinished),
+		succeededTask:  a.PatternFor(api.FinishedWithSucceeded),
+		failedTask:     a.PatternFor(api.FinishedWithFailed),
+		dispatcherDone: a.PatternFor(api.DispatcherDoneMarker),
+	}
+}

--- a/pkg/runtime/workstealer/report.go
+++ b/pkg/runtime/workstealer/report.go
@@ -14,24 +14,24 @@ func (model Model) report(c client) error {
 	var b bytes.Buffer
 	writer := tabwriter.NewWriter(&b, 0, 8, 1, '\t', tabwriter.AlignRight)
 
-	fmt.Fprintf(writer, "lunchpail.io\tunassigned\t%d\t\t\t\t\t%s\t%s\n", len(model.UnassignedTasks), c.Spec.RunName, now.Format(time.UnixDate))
-	fmt.Fprintf(writer, "lunchpail.io\tdispatcherDone\t%v\t\t\t\t\t%s\n", model.DispatcherDone, c.Spec.RunName)
-	fmt.Fprintf(writer, "lunchpail.io\tassigned\t%d\t\t\t\t\t%s\n", len(model.AssignedTasks), c.Spec.RunName)
-	fmt.Fprintf(writer, "lunchpail.io\tprocessing\t\t%d\t\t\t\t%s\n", len(model.ProcessingTasks), c.Spec.RunName)
-	fmt.Fprintf(writer, "lunchpail.io\tdone\t\t\t%d\t%d\t\t%s\n", len(model.SuccessfulTasks), len(model.FailedTasks), c.Spec.RunName)
-	fmt.Fprintf(writer, "lunchpail.io\tliveworkers\t%d\t\t\t\t\t%s\n", len(model.LiveWorkers), c.Spec.RunName)
-	fmt.Fprintf(writer, "lunchpail.io\tdeadworkers\t%d\t\t\t\t\t%s\n", len(model.DeadWorkers), c.Spec.RunName)
+	fmt.Fprintf(writer, "lunchpail.io\tunassigned\t%d\t\t\t\t\t%s\t%s\n", len(model.UnassignedTasks), c.PathArgs.RunName, now.Format(time.UnixDate))
+	fmt.Fprintf(writer, "lunchpail.io\tdispatcherDone\t%v\t\t\t\t\t%s\n", model.DispatcherDone, c.PathArgs.RunName)
+	fmt.Fprintf(writer, "lunchpail.io\tassigned\t%d\t\t\t\t\t%s\n", len(model.AssignedTasks), c.PathArgs.RunName)
+	fmt.Fprintf(writer, "lunchpail.io\tprocessing\t\t%d\t\t\t\t%s\n", len(model.ProcessingTasks), c.PathArgs.RunName)
+	fmt.Fprintf(writer, "lunchpail.io\tdone\t\t\t%d\t%d\t\t%s\n", len(model.SuccessfulTasks), len(model.FailedTasks), c.PathArgs.RunName)
+	fmt.Fprintf(writer, "lunchpail.io\tliveworkers\t%d\t\t\t\t\t%s\n", len(model.LiveWorkers), c.PathArgs.RunName)
+	fmt.Fprintf(writer, "lunchpail.io\tdeadworkers\t%d\t\t\t\t\t%s\n", len(model.DeadWorkers), c.PathArgs.RunName)
 
 	for _, worker := range model.LiveWorkers {
 		fmt.Fprintf(
-			writer, "lunchpail.io\tliveworker\t%d\t%d\t%d\t%d\t%s\t%s\t%v\n",
-			len(worker.assignedTasks), len(worker.processingTasks), worker.nSuccess, worker.nFail, worker.name, c.Spec.RunName, worker.killfilePresent,
+			writer, "lunchpail.io\tliveworker\t%d\t%d\t%d\t%d\t%s/%s\t%s\t%v\n",
+			len(worker.assignedTasks), len(worker.processingTasks), worker.nSuccess, worker.nFail, worker.pool, worker.name, c.PathArgs.RunName, worker.killfilePresent,
 		)
 	}
 	for _, worker := range model.DeadWorkers {
 		fmt.Fprintf(
-			writer, "lunchpail.io\tdeadworker\t%d\t%d\t%d\t%d\t%s\t%s\n",
-			len(worker.assignedTasks), len(worker.processingTasks), worker.nSuccess, worker.nFail, worker.name, c.Spec.RunName,
+			writer, "lunchpail.io\tdeadworker\t%d\t%d\t%d\t%d\t%s/%s\t%s\n",
+			len(worker.assignedTasks), len(worker.processingTasks), worker.nSuccess, worker.nFail, worker.pool, worker.name, c.PathArgs.RunName,
 		)
 	}
 	fmt.Fprintln(writer, "lunchpail.io\t---")

--- a/tests/bin/pipelines.sh
+++ b/tests/bin/pipelines.sh
@@ -55,10 +55,16 @@ function tester {
     bb=${b%%.*}
     actual=$(dirname "$input")/"$bb".output.$ext
     expected="$input"
+
+    if [[ -e "$actual" ]]
+    then echo "✅ PASS the output file exists test=$1"
+    else echo "❌ FAIL missing output file test=$1" && exit 1
+    fi
+    
     actual_sha256=$(cat "$actual" | sha256sum)
     expected_sha256=$(cat "$expected" | sha256sum)
     if [[ "$actual_sha256" = "$expected_sha256" ]]
-    then echo "✅ PASS the output file is valid file=$actual test=$TEST_NAME"
+    then echo "✅ PASS the output file is valid file=$actual test=$1"
     else echo "❌ FAIL mismatched sha256 on output file file=$actual actual_sha256=$actual_sha256 expected_sha256=$expected_sha256 test=$1" && exit 1
     fi
 }

--- a/tests/bin/run.sh
+++ b/tests/bin/run.sh
@@ -110,7 +110,7 @@ then
         fi
     else
         "$SCRIPTDIR"/up.sh $testname &
-        # for debugging: "$testapp" logs -c workerstealer -t $LUNCHPAIL_TARGET -f &
+        # "$testapp" logs -c workstealer -t $LUNCHPAIL_TARGET -f &
     fi
 
     if [[ -e "$1"/init.sh ]]; then


### PR DESCRIPTION
use go templates and clean up the way we lay files out to allow for pipelines

this should help #22 and #25; for the latter, search for the comment 
> // Future readers: adjust SetLimit to allow "pod packing"

## TODOs

- there are still some remnant uses of queue.client.Paths.Bucket
- there are still some remnant uses of QueuePath and llir.Component.QueuePrefixPath and related env vars
- there are some hard-wired `Step: 0` that we'll need to figure out
- a refactor is past due; we should move the queue paths into pkg/ir (it is still in pkg/fe/transformer/api even with this change)