### PR TITLE
test: enable watch mode for tests

### DIFF
--- a/tests/bin/run.sh
+++ b/tests/bin/run.sh
@@ -110,7 +110,7 @@ then
         fi
     else
         "$SCRIPTDIR"/up.sh $testname &
-        # for debugging: "$testapp" logs -c workers -t $LUNCHPAIL_TARGET -f &
+        # for debugging: "$testapp" logs -c workerstealer -t $LUNCHPAIL_TARGET -f &
     fi
 
     if [[ -e "$1"/init.sh ]]; then

--- a/tests/bin/up.sh
+++ b/tests/bin/up.sh
@@ -16,4 +16,4 @@ eval $testapp up \
          $QUEUE \
          --create-cluster \
          --target=${LUNCHPAIL_TARGET:-kubernetes} \
-         --watch=false
+         --watch=true


### PR DESCRIPTION
Previously, up --watch meant to use the "modal"/full screen status UI which breaks tests. Now that we aren't doing that, it is helpful to watch during tests so that we can see worker logs.