### PR TITLE
refactor: remove 'QueuePrefixPath' as it is no longer needed

### DIFF
--- a/pkg/be/backend.go
+++ b/pkg/be/backend.go
@@ -32,10 +32,10 @@ type Backend interface {
 	InstanceCount(ctx context.Context, c lunchpail.Component, runname string) (int, error)
 
 	// Queue properties for a given run
-	Queue(ctx context.Context, runname string) (endpoint, accessKeyID, secretAccessKey, bucket, prefixPath string, err error)
+	Queue(ctx context.Context, runname string) (endpoint, accessKeyID, secretAccessKey, bucket string, err error)
 
 	// Queue properties for a given run, plus ensure access to the endpoint from this client
-	AccessQueue(ctx context.Context, runname string) (endpoint, accessKeyID, secretAccessKey, bucket, prefixPath string, stop func(), err error)
+	AccessQueue(ctx context.Context, runname string) (endpoint, accessKeyID, secretAccessKey, bucket string, stop func(), err error)
 
 	// Return a streamer
 	Streamer(ctx context.Context, runname string) streamer.Streamer

--- a/pkg/be/ibmcloud/queue.go
+++ b/pkg/be/ibmcloud/queue.go
@@ -6,12 +6,12 @@ import (
 )
 
 // Queue properties for a given run, plus ensure access to the endpoint from this client
-func (backend Backend) AccessQueue(ctx context.Context, runname string) (endpoint, accessKeyID, secretAccessKey, bucket, prefixPath string, stop func(), err error) {
+func (backend Backend) AccessQueue(ctx context.Context, runname string) (endpoint, accessKeyID, secretAccessKey, bucket string, stop func(), err error) {
 	err = fmt.Errorf("Unsupported operation: 'AccessQueue'")
 	return
 }
 
-func (backend Backend) Queue(ctx context.Context, runname string) (endpoint, accessKeyID, secretAccessKey, bucket, prefixPath string, err error) {
+func (backend Backend) Queue(ctx context.Context, runname string) (endpoint, accessKeyID, secretAccessKey, bucket string, err error) {
 	err = fmt.Errorf("Unsupported operation: 'Queue'")
 	return
 }

--- a/pkg/be/kubernetes/common/values.go
+++ b/pkg/be/kubernetes/common/values.go
@@ -3,7 +3,6 @@ package common
 import (
 	"fmt"
 
-	"lunchpail.io/pkg/fe/transformer/api"
 	"lunchpail.io/pkg/ir/llir"
 	"lunchpail.io/pkg/lunchpail"
 )
@@ -32,7 +31,6 @@ func Values(ir llir.LLIR, opts Options) ([]string, error) {
 		"lunchpail.taskqueue.bucket=" + ir.Queue.Bucket,
 		"lunchpail.taskqueue.accessKey=" + ir.Queue.AccessKey,
 		"lunchpail.taskqueue.secretKey=" + ir.Queue.SecretKey,
-		"lunchpail.taskqueue.prefixPath=" + api.QueuePrefixPath(ir.Queue, ir.RunName),
 		"lunchpail.image.registry=" + lunchpail.ImageRegistry,
 		"lunchpail.image.repo=" + lunchpail.ImageRepo,
 		"lunchpail.image.version=" + lunchpail.Version(),

--- a/pkg/be/kubernetes/queue.go
+++ b/pkg/be/kubernetes/queue.go
@@ -15,8 +15,8 @@ import (
 )
 
 // Queue properties for a given run, plus ensure access to the endpoint from this client
-func (backend Backend) AccessQueue(ctx context.Context, runname string) (endpoint, accessKeyID, secretAccessKey, bucket, prefixPath string, stop func(), err error) {
-	endpoint, accessKeyID, secretAccessKey, bucket, prefixPath, err = backend.Queue(ctx, runname)
+func (backend Backend) AccessQueue(ctx context.Context, runname string) (endpoint, accessKeyID, secretAccessKey, bucket string, stop func(), err error) {
+	endpoint, accessKeyID, secretAccessKey, bucket, err = backend.Queue(ctx, runname)
 	if err != nil {
 		return
 	}
@@ -79,12 +79,11 @@ func portFromEndpoint(endpoint string) (int, error) {
 	return port, nil
 }
 
-func (backend Backend) Queue(ctx context.Context, runname string) (endpoint, accessKeyID, secretAccessKey, bucket, prefixPath string, err error) {
+func (backend Backend) Queue(ctx context.Context, runname string) (endpoint, accessKeyID, secretAccessKey, bucket string, err error) {
 	endpoint = os.Getenv("lunchpail_queue_endpoint")
 	accessKeyID = os.Getenv("lunchpail_queue_accessKeyID")
 	secretAccessKey = os.Getenv("lunchpail_queue_secretAccessKey")
 	bucket = os.Getenv("LUNCHPAIL_QUEUE_BUCKET")
-	prefixPath = os.Getenv("LUNCHPAIL_QUEUE_PATH")
 	err = nil
 
 	if endpoint == "" {
@@ -119,13 +118,6 @@ func (backend Backend) Queue(ctx context.Context, runname string) (endpoint, acc
 			return
 		} else {
 			secretAccessKey = string(bytes)
-		}
-
-		if bytes, ok := secret.Data["queuePrefixPath"]; !ok {
-			err = fmt.Errorf("Secret is missing 'queuePrefixPath'")
-			return
-		} else {
-			prefixPath = string(bytes)
 		}
 
 		if bytes, ok := secret.Data["bucket"]; !ok {

--- a/pkg/be/kubernetes/shell/chart/templates/containers/main.yaml
+++ b/pkg/be/kubernetes/shell/chart/templates/containers/main.yaml
@@ -8,8 +8,8 @@
       touch /tmp/alive # for readiness probe
 {{ .Values.command | indent 6 }}
   env:
-    - name: LUNCHPAIL_QUEUE_PATH
-      value: {{ .Values.taskqueue.prefixPath }}
+    - name: LUNCHPAIL_QUEUE_BUCKET
+      value: {{ .Values.taskqueue.bucket }}
     {{- include "workdir/env" . | indent 4 }}
     {{- if .Values.lunchpail.debug }}
     - name: DEBUG

--- a/pkg/be/kubernetes/shell/template.go
+++ b/pkg/be/kubernetes/shell/template.go
@@ -69,7 +69,7 @@ func Template(ir llir.LLIR, c llir.ShellComponent, namespace string, opts common
 		"workers.gpu=" + strconv.Itoa(c.Sizing.Gpu),
 		"securityContext=" + securityContext,
 		"containerSecurityContext=" + containerSecurityContext,
-		"taskqueue.prefixPath=" + c.QueuePrefixPath,
+		"taskqueue.bucket=" + ir.Queue.Bucket,
 		"volumes=" + volumes,
 		"volumeMounts=" + volumeMounts,
 		"initContainers=" + initContainers,

--- a/pkg/be/local/queue.go
+++ b/pkg/be/local/queue.go
@@ -6,18 +6,17 @@ import (
 	"os"
 
 	"lunchpail.io/pkg/be/local/files"
-	"lunchpail.io/pkg/fe/transformer/api"
 	"lunchpail.io/pkg/ir/llir"
 )
 
 // Queue properties for a given run, plus ensure access to the endpoint from this client
-func (backend Backend) AccessQueue(ctx context.Context, runname string) (endpoint, accessKeyID, secretAccessKey, bucket, prefixPath string, stop func(), err error) {
-	endpoint, accessKeyID, secretAccessKey, bucket, prefixPath, err = backend.Queue(ctx, runname)
+func (backend Backend) AccessQueue(ctx context.Context, runname string) (endpoint, accessKeyID, secretAccessKey, bucket string, stop func(), err error) {
+	endpoint, accessKeyID, secretAccessKey, bucket, err = backend.Queue(ctx, runname)
 	stop = func() {}
 	return
 }
 
-func (backend Backend) Queue(ctx context.Context, runname string) (endpoint, accessKeyID, secretAccessKey, bucket, prefixPath string, err error) {
+func (backend Backend) Queue(ctx context.Context, runname string) (endpoint, accessKeyID, secretAccessKey, bucket string, err error) {
 	spec, rerr := restoreQueue(runname)
 	if rerr != nil {
 		err = rerr
@@ -29,7 +28,6 @@ func (backend Backend) Queue(ctx context.Context, runname string) (endpoint, acc
 	accessKeyID = spec.AccessKey
 	secretAccessKey = spec.SecretKey
 	bucket = spec.Bucket
-	prefixPath = api.QueuePrefixPath(spec, runname)
 	return
 }
 

--- a/pkg/be/local/shell/spawn.go
+++ b/pkg/be/local/shell/spawn.go
@@ -92,7 +92,7 @@ func addEnv(c llir.ShellComponent, q llir.Queue) ([]string, error) {
 		"HOME=" + os.Getenv("HOME"),
 		"LUNCHPAIL_COMPONENT=" + string(c.C()),
 		"LUNCHPAIL_EXE=" + absPathToThisExe,
-		"LUNCHPAIL_QUEUE_PATH=" + c.QueuePrefixPath,
+		"LUNCHPAIL_QUEUE_BUCKET=" + q.Bucket,
 		"LUNCHPAIL_POD_NAME=" + c.InstanceName,
 		"LUNCHPAIL_VENV_CACHEDIR=" + os.Getenv("LUNCHPAIL_VENV_CACHEDIR"),
 		"TEST_QUEUE_ENDPOINT=" + q.Endpoint,

--- a/pkg/fe/transformer/api/shell/lower.go
+++ b/pkg/fe/transformer/api/shell/lower.go
@@ -30,9 +30,6 @@ func LowerAsComponent(buildName, runname string, app hlir.Application, ir llir.L
 	if component.Sizing.Workers == 0 {
 		component.Sizing = api.ApplicationSizing(app, opts)
 	}
-	if component.QueuePrefixPath == "" {
-		component.QueuePrefixPath = api.QueuePrefixPath(ir.Queue, runname)
-	}
 	if component.InstanceName == "" {
 		component.InstanceName = runname
 	}

--- a/pkg/fe/transformer/api/workerpool/lower.go
+++ b/pkg/fe/transformer/api/workerpool/lower.go
@@ -19,7 +19,6 @@ func Lower(buildName, runname string, app hlir.Application, pool hlir.WorkerPool
 	spec.Sizing = api.WorkerpoolSizing(pool, app, opts)
 	spec.GroupName = pool.Metadata.Name
 	spec.InstanceName = fmt.Sprintf("%s-%s", pool.Metadata.Name, runname)
-	spec.QueuePrefixPath = api.QueuePrefixPathForWorker(ir.Queue, runname, pool.Metadata.Name)
 
 	startupDelay, err := parseHumanTime(pool.Spec.StartupDelay)
 	if err != nil {

--- a/pkg/ir/llir/shell.go
+++ b/pkg/ir/llir/shell.go
@@ -20,9 +20,6 @@ type ShellComponent struct {
 	// Identifies the group this component is part of, e.g. the original name of the workerpool (i.e. without run id, component, ...)
 	GroupName string
 
-	// Where runners of this instance should pick up or dispatch queue data
-	QueuePrefixPath string
-
 	// Sizing of this instance
 	Sizing RunSizeConfig
 }

--- a/pkg/runtime/queue/client.go
+++ b/pkg/runtime/queue/client.go
@@ -75,7 +75,7 @@ func NewS3ClientForRun(ctx context.Context, backend be.Backend, runname string) 
 		runname = run.Name
 	}
 
-	endpoint, accessKeyId, secretAccessKey, _, prefixPath, stop, err := backend.AccessQueue(ctx, runname)
+	endpoint, accessKeyId, secretAccessKey, bucket, stop, err := backend.AccessQueue(ctx, runname)
 	if err != nil {
 		return S3ClientStop{}, err
 	}
@@ -85,7 +85,7 @@ func NewS3ClientForRun(ctx context.Context, backend be.Backend, runname string) 
 		return S3ClientStop{}, err
 	}
 
-	if paths, err := pathsFor(prefixPath); err != nil {
+	if paths, err := pathsFor(bucket); err != nil {
 		return S3ClientStop{}, err
 	} else {
 		c.Paths = paths

--- a/pkg/runtime/queue/paths.go
+++ b/pkg/runtime/queue/paths.go
@@ -1,26 +1,15 @@
 package queue
 
-import (
-	"os"
-	"strings"
-)
-
-const (
-	inboxFolder  = "inbox"
-	outboxFolder = "outbox"
-)
+import "os"
 
 type filepaths struct {
 	Bucket string
 }
 
 func pathsForRun() (filepaths, error) {
-	return pathsFor(os.Getenv("LUNCHPAIL_QUEUE_PATH"))
+	return pathsFor(os.Getenv("LUNCHPAIL_QUEUE_BUCKET"))
 }
 
-func pathsFor(queuePrefixPath string) (filepaths, error) {
-	fullPrefix := strings.Split(queuePrefixPath, "/")
-	bucket := fullPrefix[0]
-
+func pathsFor(bucket string) (filepaths, error) {
 	return filepaths{bucket}, nil
 }


### PR DESCRIPTION
the queue path work #434 renders the notion of "queue prefix path" obsolete.