### PR TITLE
fix: avoid hard-coding Step by passing around a "run context" rather than just run name

### DIFF
--- a/cmd/subcommands/component/workstealer/run.go
+++ b/cmd/subcommands/component/workstealer/run.go
@@ -20,16 +20,15 @@ func Run() *cobra.Command {
 	var pollingInterval int
 	cmd.Flags().IntVar(&pollingInterval, "polling-interval", 3, "If polling is employed, the interval between probes")
 
-	runOpts := options.AddBucketAndRunOptions(cmd)
-
-	var step int
-	cmd.Flags().IntVar(&step, "step", 0, "Which step are we part of")
-	cmd.MarkFlagRequired("step")
-
 	lopts := options.AddLogOptions(cmd)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		return workstealer.Run(context.Background(), queue.RunContext{Bucket: runOpts.Bucket, RunName: runOpts.Run, Step: step}, workstealer.Options{PollingInterval: pollingInterval, LogOptions: *lopts})
+		run, err := queue.LoadRunContextInsideComponent("")
+		if err != nil {
+			return err
+		}
+
+		return workstealer.Run(context.Background(), run, workstealer.Options{PollingInterval: pollingInterval, LogOptions: *lopts})
 	}
 
 	return cmd

--- a/cmd/subcommands/queue/cat.go
+++ b/cmd/subcommands/queue/cat.go
@@ -9,6 +9,7 @@ import (
 
 	"lunchpail.io/cmd/options"
 	"lunchpail.io/pkg/be"
+	q "lunchpail.io/pkg/ir/queue"
 	"lunchpail.io/pkg/runtime/queue"
 )
 
@@ -35,7 +36,12 @@ func Cat() *cobra.Command {
 			return err
 		}
 
-		return queue.Qcat(ctx, backend, runOpts.Run, args[0])
+		run, err := q.LoadRunContextInsideComponent(runOpts.Run)
+		if err != nil {
+			return err
+		}
+
+		return queue.Qcat(ctx, backend, run, args[0])
 	}
 
 	return cmd

--- a/cmd/subcommands/queue/done.go
+++ b/cmd/subcommands/queue/done.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"lunchpail.io/cmd/options"
+	q "lunchpail.io/pkg/ir/queue"
 	"lunchpail.io/pkg/runtime/queue"
 )
 
@@ -17,10 +18,14 @@ func Done() *cobra.Command {
 		Args:  cobra.MatchAll(cobra.OnlyValidArgs),
 	}
 	logOpts := options.AddLogOptions(cmd)
-	runOpts := options.AddRequiredRunOptions(cmd)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		return queue.Qdone(context.Background(), runOpts.Run, *logOpts)
+		run, err := q.LoadRunContextInsideComponent("")
+		if err != nil {
+			return err
+		}
+
+		return queue.Qdone(context.Background(), run, *logOpts)
 	}
 
 	return cmd

--- a/cmd/subcommands/queue/drain.go
+++ b/cmd/subcommands/queue/drain.go
@@ -9,6 +9,7 @@ import (
 
 	"lunchpail.io/cmd/options"
 	"lunchpail.io/pkg/be"
+	q "lunchpail.io/pkg/ir/queue"
 	"lunchpail.io/pkg/runtime/queue"
 )
 
@@ -24,7 +25,7 @@ func Drain() *cobra.Command {
 		panic(err)
 	}
 
-	runOpts := options.AddRequiredRunOptions(cmd)
+	runOpts := options.AddRunOptions(cmd)
 	options.AddTargetOptionsTo(cmd, &opts)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
@@ -34,7 +35,12 @@ func Drain() *cobra.Command {
 			return err
 		}
 
-		return queue.Drain(ctx, backend, runOpts.Run)
+		run, err := q.LoadRunContextInsideComponent(runOpts.Run)
+		if err != nil {
+			return err
+		}
+
+		return queue.Drain(ctx, backend, run)
 	}
 
 	return cmd

--- a/cmd/subcommands/queue/ls.go
+++ b/cmd/subcommands/queue/ls.go
@@ -11,6 +11,7 @@ import (
 	"lunchpail.io/cmd/options"
 	"lunchpail.io/pkg/be"
 	"lunchpail.io/pkg/be/runs/util"
+	q "lunchpail.io/pkg/ir/queue"
 	"lunchpail.io/pkg/runtime/queue"
 )
 
@@ -50,7 +51,13 @@ func Ls() *cobra.Command {
 			}
 			run = rrun.Name
 		}
-		files, errors, err := queue.Ls(ctx, backend, run, path)
+
+		runContext, err := q.LoadRunContextInsideComponent(run)
+		if err != nil {
+			return err
+		}
+
+		files, errors, err := queue.Ls(ctx, backend, runContext, path)
 		if err != nil {
 			return err
 		}

--- a/cmd/subcommands/queue/upload.go
+++ b/cmd/subcommands/queue/upload.go
@@ -9,6 +9,7 @@ import (
 
 	"lunchpail.io/cmd/options"
 	"lunchpail.io/pkg/be"
+	q "lunchpail.io/pkg/ir/queue"
 	"lunchpail.io/pkg/runtime/queue"
 	"lunchpail.io/pkg/runtime/queue/upload"
 )
@@ -21,14 +22,12 @@ func Upload() *cobra.Command {
 		Args:  cobra.MatchAll(cobra.ExactArgs(2), cobra.OnlyValidArgs),
 	}
 
-	var runname string
-	cmd.Flags().StringVarP(&runname, "run", "r", "", "Inspect the given run, defaulting to using the singleton run")
-
 	opts, err := options.RestoreBuildOptions()
 	if err != nil {
 		panic(err)
 	}
 
+	runOpts := options.AddRunOptions(cmd)
 	options.AddTargetOptionsTo(cmd, &opts)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
@@ -38,7 +37,8 @@ func Upload() *cobra.Command {
 			return err
 		}
 
-		return queue.UploadFiles(ctx, backend, runname, []upload.Upload{upload.Upload{Path: args[0], Bucket: args[1]}})
+		run := q.RunContext{RunName: runOpts.Run}
+		return queue.UploadFiles(ctx, backend, run, []upload.Upload{upload.Upload{Path: args[0], Bucket: args[1]}})
 	}
 
 	return cmd

--- a/pkg/be/ibmcloud/create.go
+++ b/pkg/be/ibmcloud/create.go
@@ -391,7 +391,7 @@ func createAndInitVM(ctx context.Context, vpcService *vpcv1.VpcV1, name string, 
 }
 
 func (backend Backend) SetAction(ctx context.Context, opts llir.Options, ir llir.LLIR, action Action) error {
-	runname := ir.RunName
+	runname := ir.RunName()
 
 	if action == Stop || action == Delete {
 		if err := stopOrDeleteVM(backend.vpcService, runname, backend.config.ResourceGroup.GUID, action == Delete); err != nil {

--- a/pkg/be/kubernetes/common/template.go
+++ b/pkg/be/kubernetes/common/template.go
@@ -28,7 +28,7 @@ func templateLunchpailCommonResources(ir llir.LLIR, namespace string, opts Optio
 	}
 
 	return helm.Template(
-		ir.RunName+"-common",
+		ir.RunName()+"-common",
 		namespace,
 		templatePath,
 		"", // no yaml values at the moment

--- a/pkg/be/kubernetes/common/values.go
+++ b/pkg/be/kubernetes/common/values.go
@@ -14,24 +14,24 @@ func Values(ir llir.LLIR, opts Options) ([]string, error) {
 		return []string{}, err
 	}
 
-	serviceAccount := ir.RunName
+	serviceAccount := ir.RunName()
 	if !opts.NeedsServiceAccount && imagePullSecretName == "" {
 		serviceAccount = ""
 	}
 
 	return []string{
-		"lunchpail.name=" + ir.RunName,
+		"lunchpail.name=" + ir.RunName(),
 		"lunchpail.partOf=" + ir.AppName,
 		"lunchpail.ips.name=" + imagePullSecretName,
 		"lunchpail.ips.dockerconfigjson=" + dockerconfigjson,
 		fmt.Sprintf("lunchpail.namespace.create=%v", opts.CreateNamespace),
 		"lunchpail.rbac.serviceaccount=" + serviceAccount,
-		fmt.Sprintf("lunchpail.taskqueue.auto=%v", ir.Queue.Auto),
-		"lunchpail.taskqueue.dataset=" + names.Queue(ir.RunName),
-		"lunchpail.taskqueue.endpoint=" + ir.Queue.Endpoint,
-		"lunchpail.taskqueue.bucket=" + ir.Queue.Bucket,
-		"lunchpail.taskqueue.accessKey=" + ir.Queue.AccessKey,
-		"lunchpail.taskqueue.secretKey=" + ir.Queue.SecretKey,
+		fmt.Sprintf("lunchpail.taskqueue.auto=%v", ir.Queue().Auto),
+		"lunchpail.taskqueue.dataset=" + names.Queue(ir.RunName()),
+		"lunchpail.taskqueue.endpoint=" + ir.Queue().Endpoint,
+		"lunchpail.taskqueue.bucket=" + ir.Queue().Bucket,
+		"lunchpail.taskqueue.accessKey=" + ir.Queue().AccessKey,
+		"lunchpail.taskqueue.secretKey=" + ir.Queue().SecretKey,
 		"lunchpail.image.registry=" + lunchpail.ImageRegistry,
 		"lunchpail.image.repo=" + lunchpail.ImageRepo,
 		"lunchpail.image.version=" + lunchpail.Version(),

--- a/pkg/be/kubernetes/shell/chart/templates/containers/main.yaml
+++ b/pkg/be/kubernetes/shell/chart/templates/containers/main.yaml
@@ -8,8 +8,6 @@
       touch /tmp/alive # for readiness probe
 {{ .Values.command | indent 6 }}
   env:
-    - name: LUNCHPAIL_QUEUE_BUCKET
-      value: {{ .Values.taskqueue.bucket }}
     {{- include "workdir/env" . | indent 4 }}
     {{- if .Values.lunchpail.debug }}
     - name: DEBUG

--- a/pkg/be/kubernetes/up.go
+++ b/pkg/be/kubernetes/up.go
@@ -9,8 +9,11 @@ import (
 )
 
 func (backend Backend) Up(ctx context.Context, ir llir.LLIR, opts llir.Options, isRunning chan struct{}) error {
-	if ir.Queue.Auto {
-		ir.Queue = ir.Queue.UpdateEndpoint(fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", util.Dns1035(ir.RunName+"-minio"), backend.namespace, ir.Queue.Port))
+	if ir.Queue().Auto {
+		ir.Context = llir.Context{
+			Run:   ir.Context.Run,
+			Queue: ir.Queue().UpdateEndpoint(fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", util.Dns1035(ir.RunName()+"-minio"), backend.namespace, ir.Queue().Port)),
+		}
 	}
 
 	if err := applyOperation(ctx, ir, backend.namespace, "", ApplyIt, opts); err != nil {

--- a/pkg/be/local/queue.go
+++ b/pkg/be/local/queue.go
@@ -17,27 +17,27 @@ func (backend Backend) AccessQueue(ctx context.Context, runname string) (endpoin
 }
 
 func (backend Backend) Queue(ctx context.Context, runname string) (endpoint, accessKeyID, secretAccessKey, bucket string, err error) {
-	spec, rerr := restoreQueue(runname)
+	spec, rerr := restoreContext(runname)
 	if rerr != nil {
 		err = rerr
 		return
 	}
 
 	// TODO this is hard-wired to local minio
-	endpoint = spec.Endpoint
-	accessKeyID = spec.AccessKey
-	secretAccessKey = spec.SecretKey
-	bucket = spec.Bucket
+	endpoint = spec.Queue.Endpoint
+	accessKeyID = spec.Queue.AccessKey
+	secretAccessKey = spec.Queue.SecretKey
+	bucket = spec.Queue.Bucket
 	return
 }
 
-func saveQueue(ir llir.LLIR) error {
-	f, err := files.QueueFile(ir.RunName)
+func saveContext(ir llir.LLIR) error {
+	f, err := files.QueueFile(ir.RunName())
 	if err != nil {
 		return err
 	}
 
-	b, err := json.Marshal(ir.Queue)
+	b, err := json.Marshal(ir.Context)
 	if err != nil {
 		return err
 	}
@@ -45,8 +45,8 @@ func saveQueue(ir llir.LLIR) error {
 	return os.WriteFile(f, b, 0644)
 }
 
-func restoreQueue(runname string) (llir.Queue, error) {
-	var spec llir.Queue
+func restoreContext(runname string) (llir.Context, error) {
+	var spec llir.Context
 
 	f, err := files.QueueFile(runname)
 	if err != nil {

--- a/pkg/be/local/shell/job.go
+++ b/pkg/be/local/shell/job.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Run the component as a "job", with multiple workers
-func SpawnJob(ctx context.Context, c llir.ShellComponent, q llir.Queue, runname, logdir string, opts build.LogOptions) error {
+func SpawnJob(ctx context.Context, c llir.ShellComponent, ir llir.LLIR, logdir string, opts build.LogOptions) error {
 	if c.Sizing.Workers < 1 {
 		return fmt.Errorf("Invalid worker count for %v: %d", c, c.Sizing.Workers)
 	}
@@ -20,7 +20,7 @@ func SpawnJob(ctx context.Context, c llir.ShellComponent, q llir.Queue, runname,
 
 	for workerIdx := range c.Sizing.Workers {
 		group.Go(func() error {
-			return Spawn(jobCtx, c.WithInstanceNameSuffix(fmt.Sprintf("-w%d", workerIdx)), q, runname, logdir, opts)
+			return Spawn(jobCtx, c.WithInstanceNameSuffix(fmt.Sprintf("-w%d", workerIdx)), ir, logdir, opts)
 		})
 	}
 

--- a/pkg/be/local/spawn.go
+++ b/pkg/be/local/spawn.go
@@ -9,13 +9,13 @@ import (
 	"lunchpail.io/pkg/ir/llir"
 )
 
-func (backend Backend) spawn(ctx context.Context, c llir.Component, q llir.Queue, runname, logdir string, opts build.LogOptions) error {
+func (backend Backend) spawn(ctx context.Context, c llir.Component, ir llir.LLIR, logdir string, opts build.LogOptions) error {
 	switch cc := c.(type) {
 	case llir.ShellComponent:
 		if cc.RunAsJob {
-			return shell.SpawnJob(ctx, cc, q, runname, logdir, opts)
+			return shell.SpawnJob(ctx, cc, ir, logdir, opts)
 		} else {
-			return shell.Spawn(ctx, cc, q, runname, logdir, opts)
+			return shell.Spawn(ctx, cc, ir, logdir, opts)
 		}
 	}
 

--- a/pkg/boot/down.go
+++ b/pkg/boot/down.go
@@ -11,6 +11,8 @@ import (
 	"lunchpail.io/pkg/be/runs/util"
 	"lunchpail.io/pkg/build"
 	"lunchpail.io/pkg/fe"
+	"lunchpail.io/pkg/ir/llir"
+	"lunchpail.io/pkg/ir/queue"
 )
 
 type DownOptions struct {
@@ -87,8 +89,10 @@ func Down(ctx context.Context, runname string, backend be.Backend, opts DownOpti
 		runname = singletonRun.Name
 	}
 
+	context := llir.Context{Run: queue.RunContext{RunName: runname}}
+
 	copts := toBuildOpts(opts)
-	ir, err := fe.PrepareForRun(runname, fe.PrepareOptions{}, copts)
+	ir, err := fe.PrepareForRun(context, fe.PrepareOptions{}, copts)
 	if err != nil {
 		return err
 	}

--- a/pkg/boot/io.go
+++ b/pkg/boot/io.go
@@ -14,13 +14,13 @@ import (
 
 // Behave like `cat inputs | ... > outputs`
 func catAndRedirect(ctx context.Context, inputs []string, backend be.Backend, ir llir.LLIR, opts build.LogOptions) error {
-	client, err := queue.NewS3ClientForRun(ctx, backend, ir.RunName)
+	client, err := queue.NewS3ClientForRun(ctx, backend, ir.Context.Run.RunName)
 	if err != nil {
 		return err
 	}
 	defer client.Stop()
 
-	if err := builtins.Cat(ctx, client.S3Client, ir.RunName, inputs, opts); err != nil {
+	if err := builtins.Cat(ctx, client.S3Client, ir.Context.Run, inputs, opts); err != nil {
 		return err
 	}
 
@@ -35,7 +35,7 @@ func catAndRedirect(ctx context.Context, inputs []string, backend be.Backend, ir
 			}
 			return "."
 		}
-		if err := builtins.RedirectTo(ctx, client.S3Client, ir.RunName, folderFor, opts); err != nil {
+		if err := builtins.RedirectTo(ctx, client.S3Client, ir.Context.Run, folderFor, opts); err != nil {
 			return err
 		}
 	}

--- a/pkg/boot/watch.go
+++ b/pkg/boot/watch.go
@@ -22,14 +22,14 @@ func watchLogs(ctx context.Context, backend be.Backend, ir llir.LLIR, opts Watch
 		components = lunchpail.AllComponents
 	}
 
-	err := observe.Logs(ctx, ir.RunName, backend, observe.LogsOptions{Follow: true, Verbose: opts.Verbose, Components: components})
+	err := observe.Logs(ctx, ir.RunName(), backend, observe.LogsOptions{Follow: true, Verbose: opts.Verbose, Components: components})
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 	}
 }
 
 func watchUtilization(ctx context.Context, backend be.Backend, ir llir.LLIR, opts WatchOptions) {
-	err := cpu.UI(ctx, ir.RunName, backend, cpu.CpuOptions{Verbose: opts.Verbose, NoClearScreen: true, IntervalSeconds: 10})
+	err := cpu.UI(ctx, ir.RunName(), backend, cpu.CpuOptions{Verbose: opts.Verbose, NoClearScreen: true, IntervalSeconds: 10})
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 	}

--- a/pkg/fe/transformer/api/dispatch/lower.go
+++ b/pkg/fe/transformer/api/dispatch/lower.go
@@ -9,11 +9,11 @@ import (
 )
 
 // HLIR -> LLIR for []hlir.ParameterSweep, ...
-func Lower(buildName, runname string, model hlir.HLIR, ir llir.LLIR, opts build.Options) ([]llir.Component, error) {
+func Lower(buildName string, ctx llir.Context, model hlir.HLIR, opts build.Options) ([]llir.Component, error) {
 	components := []llir.Component{}
 
 	for _, r := range model.ParameterSweeps {
-		if component, err := parametersweep.Lower(buildName, runname, r, ir, opts); err != nil {
+		if component, err := parametersweep.Lower(buildName, ctx, r, opts); err != nil {
 			return components, err
 		} else {
 			components = append(components, component)
@@ -21,7 +21,7 @@ func Lower(buildName, runname string, model hlir.HLIR, ir llir.LLIR, opts build.
 	}
 
 	for _, r := range model.ProcessS3Objects {
-		if component, err := s3.Lower(buildName, runname, r, ir, opts); err != nil {
+		if component, err := s3.Lower(buildName, ctx, r, opts); err != nil {
 			return components, err
 		} else {
 			components = append(components, component)

--- a/pkg/fe/transformer/api/dispatch/parametersweep/lower.go
+++ b/pkg/fe/transformer/api/dispatch/parametersweep/lower.go
@@ -8,17 +8,16 @@ import (
 	"lunchpail.io/pkg/lunchpail"
 )
 
-func Lower(buildName, runname string, sweep hlir.ParameterSweep, ir llir.LLIR, opts build.Options) (llir.Component, error) {
-	app, err := transpile(runname, sweep)
+func Lower(buildName string, ctx llir.Context, sweep hlir.ParameterSweep, opts build.Options) (llir.Component, error) {
+	app, err := transpile(sweep)
 	if err != nil {
 		return nil, err
 	}
 
 	return shell.LowerAsComponent(
 		buildName,
-		runname,
+		ctx,
 		app,
-		ir,
 		llir.ShellComponent{Component: lunchpail.DispatcherComponent},
 		opts,
 	)

--- a/pkg/fe/transformer/api/dispatch/parametersweep/main.sh
+++ b/pkg/fe/transformer/api/dispatch/parametersweep/main.sh
@@ -50,6 +50,6 @@ do
     # If we were asked to wait, then `queue add file` will exit with the
     # exit code of the underlying worker. Here, we intentionally
     # ignore any errors from the task.
-    $LUNCHPAIL_EXE queue add file $task $waitflag $verboseflag $debugflag --run $1
+    $LUNCHPAIL_EXE queue add file $task $waitflag $verboseflag $debugflag
     rm -f "$task"
 done

--- a/pkg/fe/transformer/api/dispatch/parametersweep/transpile.go
+++ b/pkg/fe/transformer/api/dispatch/parametersweep/transpile.go
@@ -10,15 +10,15 @@ import (
 )
 
 // Transpile hlir.ParameterSweep to hlir.Application
-func transpile(runname string, sweep hlir.ParameterSweep) (hlir.Application, error) {
+func transpile(sweep hlir.ParameterSweep) (hlir.Application, error) {
 	app := hlir.NewApplication(sweep.Metadata.Name)
 
 	app.Spec.Image = fmt.Sprintf("%s/%s/lunchpail:%s", lunchpail.ImageRegistry, lunchpail.ImageRepo, lunchpail.Version())
 	app.Spec.Role = "dispatcher"
 
 	app.Spec.Command = strings.Join([]string{
-		fmt.Sprintf(`trap "$LUNCHPAIL_EXE queue done --run %s" EXIT`, runname),
-		fmt.Sprintf("./main.sh %s", runname),
+		`trap "$LUNCHPAIL_EXE queue done" EXIT`,
+		"./main.sh",
 	}, "\n")
 
 	app.Spec.Code = []hlir.Code{

--- a/pkg/fe/transformer/api/dispatch/s3/lower.go
+++ b/pkg/fe/transformer/api/dispatch/s3/lower.go
@@ -8,17 +8,16 @@ import (
 	"lunchpail.io/pkg/lunchpail"
 )
 
-func Lower(buildName, runname string, s3 hlir.ProcessS3Objects, ir llir.LLIR, opts build.Options) (llir.Component, error) {
-	app, err := transpile(runname, s3)
+func Lower(buildName string, ctx llir.Context, s3 hlir.ProcessS3Objects, opts build.Options) (llir.Component, error) {
+	app, err := transpile(s3)
 	if err != nil {
 		return nil, err
 	}
 
 	return shell.LowerAsComponent(
 		buildName,
-		runname,
+		ctx,
 		app,
-		ir,
 		llir.ShellComponent{Component: lunchpail.DispatcherComponent},
 		opts,
 	)

--- a/pkg/fe/transformer/api/dispatch/s3/transpile.go
+++ b/pkg/fe/transformer/api/dispatch/s3/transpile.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Transpile hlir.ProcessS3Objects to hlir.Application
-func transpile(runname string, s3 hlir.ProcessS3Objects) (hlir.Application, error) {
+func transpile(s3 hlir.ProcessS3Objects) (hlir.Application, error) {
 	app := hlir.NewApplication(s3.Metadata.Name)
 
 	if s3.Spec.Rclone.RemoteName == "" {
@@ -39,8 +39,8 @@ func transpile(runname string, s3 hlir.ProcessS3Objects) (hlir.Application, erro
 
 	envPrefix := "LUNCHPAIL_PROCESS_S3_OBJECTS_"
 	app.Spec.Command = strings.Join([]string{
-		fmt.Sprintf(`trap "$LUNCHPAIL_EXE queue done --run %s" EXIT`, runname),
-		fmt.Sprintf("$LUNCHPAIL_EXE queue add s3 --run %s --repeat %d %s %s %s %s", runname, repeat, verbose, debug, s3.Spec.Path, envPrefix),
+		`trap "$LUNCHPAIL_EXE queue done" EXIT`,
+		fmt.Sprintf("$LUNCHPAIL_EXE queue add s3 --repeat %d %s %s %s %s", repeat, verbose, debug, s3.Spec.Path, envPrefix),
 	}, "\n")
 
 	app.Spec.Env = hlir.Env{}

--- a/pkg/fe/transformer/api/minio/lower.go
+++ b/pkg/fe/transformer/api/minio/lower.go
@@ -8,21 +8,20 @@ import (
 	"lunchpail.io/pkg/lunchpail"
 )
 
-func Lower(buildName, runname string, model hlir.HLIR, ir llir.LLIR, opts build.Options) (llir.Component, error) {
-	if !ir.Queue.Auto {
+func Lower(buildName string, ctx llir.Context, model hlir.HLIR, opts build.Options) (llir.Component, error) {
+	if !ctx.Queue.Auto {
 		return nil, nil
 	}
 
-	app, err := transpile(runname, ir)
+	app, err := transpile(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	component, err := shell.LowerAsComponent(
 		buildName,
-		runname,
+		ctx,
 		app,
-		ir,
 		llir.ShellComponent{Component: lunchpail.MinioComponent},
 		opts,
 	)

--- a/pkg/fe/transformer/api/minio/transpile.go
+++ b/pkg/fe/transformer/api/minio/transpile.go
@@ -9,13 +9,13 @@ import (
 )
 
 // Transpile minio to hlir.Application
-func transpile(runname string, ir llir.LLIR) (hlir.Application, error) {
-	app := hlir.NewApplication(runname + "-minio")
+func transpile(ctx llir.Context) (hlir.Application, error) {
+	app := hlir.NewApplication(ctx.Run.RunName + "-minio")
 
 	app.Spec.Image = "docker.io/minio/minio:RELEASE.2024-07-04T14-25-45Z"
 	app.Spec.Role = "queue"
-	app.Spec.Expose = []string{fmt.Sprintf("%d:%d", ir.Queue.Port, ir.Queue.Port)}
-	app.Spec.Command = fmt.Sprintf("$LUNCHPAIL_EXE component minio server --port %d --bucket %s --run %s", ir.Queue.Port, ir.Queue.Bucket, runname)
+	app.Spec.Expose = []string{fmt.Sprintf("%d:%d", ctx.Queue.Port, ctx.Queue.Port)}
+	app.Spec.Command = fmt.Sprintf("$LUNCHPAIL_EXE component minio server --port %d --bucket %s --run %s", ctx.Queue.Port, ctx.Queue.Bucket, ctx.Run.RunName)
 
 	/*app.Spec.Needs = []hlir.Needs{
 	{Name: "minio", Version: "latest"}}*/

--- a/pkg/fe/transformer/api/workerpool/lowerall.go
+++ b/pkg/fe/transformer/api/workerpool/lowerall.go
@@ -9,7 +9,7 @@ import (
 )
 
 // HLIR -> LLIR for []hlir.WorkerPool
-func LowerAll(buildName, runname string, model hlir.HLIR, ir llir.LLIR, opts build.Options) ([]llir.Component, error) {
+func LowerAll(buildName string, ctx llir.Context, model hlir.HLIR, opts build.Options) ([]llir.Component, error) {
 	components := []llir.Component{}
 
 	app, found := model.GetApplicationByRole(hlir.WorkerRole)
@@ -18,7 +18,7 @@ func LowerAll(buildName, runname string, model hlir.HLIR, ir llir.LLIR, opts bui
 	}
 
 	for _, pool := range model.WorkerPools {
-		if component, err := Lower(buildName, runname, app, pool, ir, opts); err != nil {
+		if component, err := Lower(buildName, ctx, app, pool, opts); err != nil {
 			return components, err
 		} else {
 			components = append(components, component)

--- a/pkg/fe/transformer/api/workstealer/lower.go
+++ b/pkg/fe/transformer/api/workstealer/lower.go
@@ -7,17 +7,16 @@ import (
 	"lunchpail.io/pkg/lunchpail"
 )
 
-func Lower(buildName, runname string, ir llir.LLIR, opts build.Options) (llir.Component, error) {
-	app, err := transpile(runname, ir, *opts.Log)
+func Lower(buildName string, ctx llir.Context, opts build.Options) (llir.Component, error) {
+	app, err := transpile(ctx, *opts.Log)
 	if err != nil {
 		return nil, err
 	}
 
 	return shell.LowerAsComponent(
 		buildName,
-		runname,
+		ctx,
 		app,
-		ir,
 		llir.ShellComponent{Component: lunchpail.WorkStealerComponent},
 		opts,
 	)

--- a/pkg/fe/transformer/api/workstealer/transpile.go
+++ b/pkg/fe/transformer/api/workstealer/transpile.go
@@ -11,22 +11,17 @@ import (
 )
 
 // Transpile workstealer to hlir.Application
-func transpile(runname string, ir llir.LLIR, opts build.LogOptions) (hlir.Application, error) {
-	step := 0 // TODO
-	app := hlir.NewApplication(runname + "-workstealer")
+func transpile(ctx llir.Context, opts build.LogOptions) (hlir.Application, error) {
+	app := hlir.NewApplication(ctx.Run.RunName + "-workstealer")
 
 	app.Spec.Image = fmt.Sprintf("%s/%s/lunchpail:%s", lunchpail.ImageRegistry, lunchpail.ImageRepo, lunchpail.Version())
 	app.Spec.Role = "workstealer"
-	app.Spec.Command = fmt.Sprintf("$LUNCHPAIL_EXE component workstealer run --verbose=%v --debug=%v --bucket %s --run %s --step %d",
+	app.Spec.Command = fmt.Sprintf("$LUNCHPAIL_EXE component workstealer run --verbose=%v --debug=%v",
 		opts.Verbose,
 		opts.Debug,
-		ir.Queue.Bucket,
-		runname,
-		step,
 	)
 
 	app.Spec.Env = hlir.Env{}
-	app.Spec.Env["LUNCHPAIL_RUN_NAME"] = runname
 
 	// This can help with tests
 	app.Spec.Env["LUNCHPAIL_SLEEP_BEFORE_EXIT"] = os.Getenv("LUNCHPAIL_SLEEP_BEFORE_EXIT")

--- a/pkg/fe/transformer/application.go
+++ b/pkg/fe/transformer/application.go
@@ -9,14 +9,14 @@ import (
 )
 
 // HLIR -> LLIR for []hlir.Application
-func lowerApplications(buildName, runname string, model hlir.HLIR, ir llir.LLIR, opts build.Options) ([]llir.Component, error) {
+func lowerApplications(buildName string, ctx llir.Context, model hlir.HLIR, opts build.Options) ([]llir.Component, error) {
 	components := []llir.Component{}
 
 	if workstealer.IsNeeded(model) {
 		// Note, the actual worker resources will be dealt
 		// with when a WorkerPool is created. Here, we only
 		// need to specify a WorkStealer.
-		c, err := workstealer.Lower(buildName, runname, ir, opts)
+		c, err := workstealer.Lower(buildName, ctx, opts)
 		if err != nil {
 			return nil, err
 		}
@@ -26,7 +26,7 @@ func lowerApplications(buildName, runname string, model hlir.HLIR, ir llir.LLIR,
 	// Then, for every non-Worker, we lower it as a "shell"
 	for _, app := range model.Applications {
 		if app.Spec.Role != hlir.WorkerRole {
-			c, err := shell.Lower(buildName, runname, app, ir, opts)
+			c, err := shell.Lower(buildName, ctx, app, opts)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/ir/llir/llir.go
+++ b/pkg/ir/llir/llir.go
@@ -14,19 +14,20 @@ type Component interface {
 	SetWorkers(w int) Component
 }
 
-// Specification of the queue, e.g. endpoint
-type Queue = queue.Spec
+type Context struct {
+	Run   queue.RunContext
+	Queue queue.Spec
+}
 
 type LLIR struct {
 	AppName string
-	RunName string
+
+	// The context that defines a run (run name, step, etc.)
+	Context
 
 	// Applications may provide their own Kubernetes resources
 	// that will be deployed once per run
 	AppProvidedKubernetesResources string
-
-	// Details of how to reach the queue endpoint
-	Queue
 
 	// One Component per WorkerPool, one for WorkerStealer, etc.
 	Components []Component
@@ -40,4 +41,12 @@ func (ir LLIR) HasDispatcher() bool {
 	}
 
 	return false
+}
+
+func (ir LLIR) RunName() string {
+	return ir.Context.Run.RunName
+}
+
+func (ir LLIR) Queue() queue.Spec {
+	return ir.Context.Queue
 }

--- a/pkg/ir/queue/inside-component.go
+++ b/pkg/ir/queue/inside-component.go
@@ -1,0 +1,38 @@
+package queue
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
+func LoadRunContextInsideComponent(runname string) (run RunContext, err error) {
+	if runname != "" {
+		run = RunContext{RunName: runname}
+		return
+	}
+
+	runname = os.Getenv("LUNCHPAIL_RUN_NAME")
+	bucket := os.Getenv("LUNCHPAIL_QUEUE_BUCKET")
+	stepStr := os.Getenv("LUNCHPAIL_STEP")
+
+	switch {
+	case runname == "":
+		err = fmt.Errorf("Missing LUNCHPAIL_RUN_NAME environment variable")
+	case bucket == "":
+		err = fmt.Errorf("Missing LUNCHPAIL_QUEUE_BUCKET environment variable")
+		return
+	case stepStr == "":
+		err = fmt.Errorf("Missing LUNCHPAIL_STEP environment variable")
+		return
+	}
+
+	var step int
+	step, err = strconv.Atoi(stepStr)
+	if err != nil {
+		return
+	}
+
+	run = RunContext{RunName: runname, Bucket: bucket, Step: step}
+	return
+}

--- a/pkg/runtime/builtins/cat.go
+++ b/pkg/runtime/builtins/cat.go
@@ -6,33 +6,34 @@ import (
 	"lunchpail.io/pkg/be"
 	"lunchpail.io/pkg/build"
 	"lunchpail.io/pkg/ir/hlir"
-	"lunchpail.io/pkg/runtime/queue"
+	"lunchpail.io/pkg/ir/queue"
+	s3 "lunchpail.io/pkg/runtime/queue"
 )
 
-func Cat(ctx context.Context, client queue.S3Client, runname string, inputs []string, opts build.LogOptions) error {
-	qopts := queue.AddOptions{
+func Cat(ctx context.Context, client s3.S3Client, run queue.RunContext, inputs []string, opts build.LogOptions) error {
+	qopts := s3.AddOptions{
 		S3Client:   client,
 		LogOptions: opts,
 	}
-	if err := queue.AddList(ctx, runname, inputs, qopts); err != nil {
+	if err := s3.AddList(ctx, run, inputs, qopts); err != nil {
 		return err
 	}
 
-	if err := queue.QdoneClient(ctx, client, runname, opts); err != nil {
+	if err := s3.QdoneClient(ctx, client, run, opts); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func CatClient(ctx context.Context, backend be.Backend, runname string, inputs []string, opts build.LogOptions) error {
-	client, err := queue.NewS3ClientForRun(ctx, backend, runname)
+func CatClient(ctx context.Context, backend be.Backend, run queue.RunContext, inputs []string, opts build.LogOptions) error {
+	client, err := s3.NewS3ClientForRun(ctx, backend, run.RunName)
 	if err != nil {
 		return err
 	}
 	defer client.Stop()
 
-	return Cat(ctx, client.S3Client, runname, inputs, opts)
+	return Cat(ctx, client.S3Client, run, inputs, opts)
 }
 
 func CatApp() hlir.HLIR {

--- a/pkg/runtime/builtins/redirect.go
+++ b/pkg/runtime/builtins/redirect.go
@@ -14,9 +14,7 @@ import (
 	s3 "lunchpail.io/pkg/runtime/queue"
 )
 
-func RedirectTo(ctx context.Context, client s3.S3Client, runname string, folderFor func(object string) string, opts build.LogOptions) error {
-	run := queue.RunContext{Bucket: client.Paths.Bucket, RunName: runname, Step: 0} // FIXME
-
+func RedirectTo(ctx context.Context, client s3.S3Client, run queue.RunContext, folderFor func(object string) string, opts build.LogOptions) error {
 	failures := run.AsFile(queue.FinishedWithFailed)
 	outbox := run.AsFile(queue.AssignedAndFinished)
 

--- a/pkg/runtime/queue/drain.go
+++ b/pkg/runtime/queue/drain.go
@@ -10,14 +10,14 @@ import (
 )
 
 // Drain the output tasks, allowing graceful termination
-func Drain(ctx context.Context, backend be.Backend, runname string) error {
-	c, err := NewS3ClientForRun(ctx, backend, runname)
+func Drain(ctx context.Context, backend be.Backend, run queue.RunContext) error {
+	c, err := NewS3ClientForRun(ctx, backend, run.RunName)
 	if err != nil {
 		return err
 	}
 	defer c.Stop()
+	run.Bucket = c.Paths.Bucket // TODO
 
-	run := queue.RunContext{Bucket: c.Paths.Bucket, RunName: runname, Step: 0} // FIXME
 	outbox := run.AsFile(queue.AssignedAndFinished)
 
 	group, _ := errgroup.WithContext(ctx)

--- a/pkg/runtime/queue/ls.go
+++ b/pkg/runtime/queue/ls.go
@@ -9,23 +9,22 @@ import (
 	"lunchpail.io/pkg/ir/queue"
 )
 
-func Ls(ctx context.Context, backend be.Backend, runname, path string) (<-chan string, <-chan error, error) {
-	c, err := NewS3ClientForRun(ctx, backend, runname)
+func Ls(ctx context.Context, backend be.Backend, run queue.RunContext, path string) (<-chan string, <-chan error, error) {
+	c, err := NewS3ClientForRun(ctx, backend, run.RunName)
 	if err != nil {
 		return nil, nil, err
 	}
+	run.Bucket = c.Paths.Bucket // TODO
+
+	prefix := filepath.Join(run.ListenPrefix(), path)
 
 	files := make(chan string)
 	errors := make(chan error)
-
-	run := queue.RunContext{Bucket: c.Paths.Bucket, RunName: runname, Step: 0}
-	prefix := filepath.Join(run.ListenPrefix(), path)
-
 	go func() {
 		defer c.Stop()
 		defer close(files)
 		defer close(errors)
-		for o := range c.ListObjects(c.Paths.Bucket, prefix, true) {
+		for o := range c.ListObjects(run.Bucket, prefix, true) {
 			if o.Err != nil {
 				errors <- o.Err
 			} else {

--- a/pkg/runtime/queue/qcat.go
+++ b/pkg/runtime/queue/qcat.go
@@ -8,14 +8,13 @@ import (
 	"lunchpail.io/pkg/ir/queue"
 )
 
-func Qcat(ctx context.Context, backend be.Backend, runname, path string) error {
-	c, err := NewS3ClientForRun(ctx, backend, runname)
+func Qcat(ctx context.Context, backend be.Backend, run queue.RunContext, path string) error {
+	c, err := NewS3ClientForRun(ctx, backend, run.RunName)
 	if err != nil {
 		return err
 	}
 	defer c.Stop()
 
-	run := queue.RunContext{Bucket: c.Paths.Bucket, RunName: runname, Step: 0} // FIXME
 	fullPath := filepath.Join(run.ListenPrefix(), path)
 
 	if err := c.Cat(run.Bucket, fullPath); err != nil {

--- a/pkg/runtime/queue/qdone.go
+++ b/pkg/runtime/queue/qdone.go
@@ -10,21 +10,20 @@ import (
 )
 
 // Indicate dispatching is done, with given client
-func QdoneClient(ctx context.Context, c S3Client, runname string, opts build.LogOptions) (err error) {
+func QdoneClient(ctx context.Context, c S3Client, run queue.RunContext, opts build.LogOptions) (err error) {
 	if opts.Verbose {
 		fmt.Fprintf(os.Stderr, "Done with dispatching\n")
 	}
 
-	run := queue.RunContext{Bucket: c.Paths.Bucket, RunName: runname, Step: 0} // FIXME
 	return c.Touch(run.Bucket, run.AsFile(queue.DispatcherDoneMarker))
 }
 
 // Indicate dispatching is done
-func Qdone(ctx context.Context, runname string, opts build.LogOptions) error {
+func Qdone(ctx context.Context, run queue.RunContext, opts build.LogOptions) error {
 	c, err := NewS3Client(ctx) // pull config from env vars
 	if err != nil {
 		return err
 	}
 
-	return QdoneClient(ctx, c, runname, opts)
+	return QdoneClient(ctx, c, run, opts)
 }

--- a/pkg/runtime/queue/upload.go
+++ b/pkg/runtime/queue/upload.go
@@ -11,15 +11,17 @@ import (
 	"time"
 
 	"lunchpail.io/pkg/be"
+	"lunchpail.io/pkg/ir/queue"
 	"lunchpail.io/pkg/runtime/queue/upload"
 )
 
-func UploadFiles(ctx context.Context, backend be.Backend, runname string, specs []upload.Upload) error {
-	s3, err := NewS3ClientForRun(ctx, backend, runname)
+func UploadFiles(ctx context.Context, backend be.Backend, run queue.RunContext, specs []upload.Upload) error {
+	s3, err := NewS3ClientForRun(ctx, backend, run.RunName)
 	if err != nil {
 		return err
 	}
 	defer s3.Stop()
+	run.Bucket = s3.Paths.Bucket // TODO
 
 	for _, spec := range specs {
 		fmt.Fprintf(os.Stderr, "Preparing upload with mkdirp on s3 bucket=%s\n", spec.Bucket)

--- a/pkg/runtime/queue/wait.go
+++ b/pkg/runtime/queue/wait.go
@@ -121,8 +121,8 @@ func (s3 S3Client) StopListening(bucket string) error {
 }
 
 // Wait for the given enqueued task to appear in the outbox
-func (c S3Client) WaitForCompletion(runname, task string, verbose bool) (int, error) {
-	run := queue.RunContext{Bucket: c.Paths.Bucket, RunName: runname, Step: 0, Task: task} // FIXME
+func (c S3Client) WaitForCompletion(run queue.RunContext, task string, verbose bool) (int, error) {
+	run = run.ForTask(task)
 	codesDir := run.AsDir(queue.FinishedWithCode)
 
 	if verbose {


### PR DESCRIPTION
# TODOs

- there are still some uses of pkg/runtime/queue/S3Client.Paths.Bucket
- we need to figure out a consistent story for loading a run context. we have a couple of stories.... `NewS3ClientForRun` which gives... some of the run context (queue-specific context); we have `util.Singleton()` which gives some other subset (a RunName)... and we have `pkg/ir/queue.LoadRunContextInsideComponent()` which gives a different subset.