### PR TITLE
fix: workstealer wasn't responding to AssignedAndFinished (aka outbox) tasks

### DIFF
--- a/cmd/options/target.go
+++ b/cmd/options/target.go
@@ -21,7 +21,17 @@ func AddTargetOptionsTo(cmd *cobra.Command, opts *build.Options) *build.TargetOp
 		opts.Target.Namespace = build.Name()
 	}
 	if opts.Target.Platform == "" {
-		opts.Target.Platform = target.Kubernetes
+		// consult env var for target
+		if t, err := target.FromEnv(); err != nil {
+			panic(err)
+		} else if t != "" {
+			opts.Target.Platform = t
+		}
+
+		if opts.Target.Platform == "" {
+			// hard-wired default target
+			opts.Target.Platform = target.Kubernetes
+		}
 	}
 
 	cmd.Flags().VarP(&opts.Target.Platform, "target", "t", "Deployment target [local, kubernetes, ibmcloud, skypilot]")

--- a/cmd/subcommands/component/workstealer/run.go
+++ b/cmd/subcommands/component/workstealer/run.go
@@ -20,6 +20,9 @@ func Run() *cobra.Command {
 	var pollingInterval int
 	cmd.Flags().IntVar(&pollingInterval, "polling-interval", 3, "If polling is employed, the interval between probes")
 
+	var selfDestruct bool
+	cmd.Flags().BoolVar(&selfDestruct, "self-destruct", false, "Automatically tear down the run when all output has been consumed?")
+
 	lopts := options.AddLogOptions(cmd)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
@@ -28,7 +31,7 @@ func Run() *cobra.Command {
 			return err
 		}
 
-		return workstealer.Run(context.Background(), run, workstealer.Options{PollingInterval: pollingInterval, LogOptions: *lopts})
+		return workstealer.Run(context.Background(), run, workstealer.Options{PollingInterval: pollingInterval, SelfDestruct: selfDestruct, LogOptions: *lopts})
 	}
 
 	return cmd

--- a/cmd/subcommands/status/instances.go
+++ b/cmd/subcommands/status/instances.go
@@ -13,6 +13,7 @@ import (
 	"lunchpail.io/cmd/options"
 	"lunchpail.io/pkg/be"
 	"lunchpail.io/pkg/be/runs/util"
+	"lunchpail.io/pkg/ir/queue"
 	"lunchpail.io/pkg/lunchpail"
 )
 
@@ -69,7 +70,7 @@ func Instances() *cobra.Command {
 				}
 			}
 
-			count, err := backend.InstanceCount(ctx, *component, runname)
+			count, err := backend.InstanceCount(ctx, *component, queue.RunContext{RunName: runname})
 			if err != nil {
 				if wait {
 					waitItOut(*component, -1, err)

--- a/pkg/be/backend.go
+++ b/pkg/be/backend.go
@@ -6,6 +6,7 @@ import (
 	"lunchpail.io/pkg/be/runs"
 	"lunchpail.io/pkg/be/streamer"
 	"lunchpail.io/pkg/ir/llir"
+	"lunchpail.io/pkg/ir/queue"
 	"lunchpail.io/pkg/lunchpail"
 )
 
@@ -29,14 +30,14 @@ type Backend interface {
 	ListRuns(ctx context.Context, all bool) ([]runs.Run, error)
 
 	// Number of instances of the given component for the given run
-	InstanceCount(ctx context.Context, c lunchpail.Component, runname string) (int, error)
+	InstanceCount(ctx context.Context, c lunchpail.Component, run queue.RunContext) (int, error)
 
 	// Queue properties for a given run
-	Queue(ctx context.Context, runname string) (endpoint, accessKeyID, secretAccessKey, bucket string, err error)
+	Queue(ctx context.Context, run queue.RunContext) (endpoint, accessKeyID, secretAccessKey, bucket string, err error)
 
 	// Queue properties for a given run, plus ensure access to the endpoint from this client
-	AccessQueue(ctx context.Context, runname string) (endpoint, accessKeyID, secretAccessKey, bucket string, stop func(), err error)
+	AccessQueue(ctx context.Context, run queue.RunContext) (endpoint, accessKeyID, secretAccessKey, bucket string, stop func(), err error)
 
 	// Return a streamer
-	Streamer(ctx context.Context, runname string) streamer.Streamer
+	Streamer(ctx context.Context, run queue.RunContext) streamer.Streamer
 }

--- a/pkg/be/ibmcloud/instances.go
+++ b/pkg/be/ibmcloud/instances.go
@@ -3,10 +3,11 @@ package ibmcloud
 import (
 	"context"
 
+	"lunchpail.io/pkg/ir/queue"
 	"lunchpail.io/pkg/lunchpail"
 )
 
 // Number of instances of the given component for the given run
-func (backend Backend) InstanceCount(ctx context.Context, c lunchpail.Component, runname string) (int, error) {
+func (backend Backend) InstanceCount(ctx context.Context, c lunchpail.Component, run queue.RunContext) (int, error) {
 	return 0, nil
 }

--- a/pkg/be/ibmcloud/queue.go
+++ b/pkg/be/ibmcloud/queue.go
@@ -3,15 +3,17 @@ package ibmcloud
 import (
 	"context"
 	"fmt"
+
+	"lunchpail.io/pkg/ir/queue"
 )
 
 // Queue properties for a given run, plus ensure access to the endpoint from this client
-func (backend Backend) AccessQueue(ctx context.Context, runname string) (endpoint, accessKeyID, secretAccessKey, bucket string, stop func(), err error) {
+func (backend Backend) AccessQueue(ctx context.Context, run queue.RunContext) (endpoint, accessKeyID, secretAccessKey, bucket string, stop func(), err error) {
 	err = fmt.Errorf("Unsupported operation: 'AccessQueue'")
 	return
 }
 
-func (backend Backend) Queue(ctx context.Context, runname string) (endpoint, accessKeyID, secretAccessKey, bucket string, err error) {
+func (backend Backend) Queue(ctx context.Context, run queue.RunContext) (endpoint, accessKeyID, secretAccessKey, bucket string, err error) {
 	err = fmt.Errorf("Unsupported operation: 'Queue'")
 	return
 }

--- a/pkg/be/ibmcloud/streamer.go
+++ b/pkg/be/ibmcloud/streamer.go
@@ -4,15 +4,16 @@ import (
 	"context"
 
 	"lunchpail.io/pkg/be/streamer"
+	"lunchpail.io/pkg/ir/queue"
 )
 
 type Streamer struct {
 	context.Context
-	runname string
+	run     queue.RunContext
 	backend Backend
 }
 
 // Return a streamer
-func (backend Backend) Streamer(ctx context.Context, runname string) streamer.Streamer {
-	return Streamer{ctx, runname, backend}
+func (backend Backend) Streamer(ctx context.Context, run queue.RunContext) streamer.Streamer {
+	return Streamer{ctx, run, backend}
 }

--- a/pkg/be/kubernetes/events.go
+++ b/pkg/be/kubernetes/events.go
@@ -40,7 +40,7 @@ func (streamer Streamer) RunEvents() (chan events.Message, error) {
 	}
 
 	c := make(chan events.Message)
-	go stream(streamer.runname, eventWatcher, c)
+	go stream(streamer.run.RunName, eventWatcher, c)
 
 	return c, nil
 }

--- a/pkg/be/kubernetes/instances.go
+++ b/pkg/be/kubernetes/instances.go
@@ -5,11 +5,12 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"lunchpail.io/pkg/ir/queue"
 	"lunchpail.io/pkg/lunchpail"
 )
 
 // Number of instances of the given component for the given run
-func (backend Backend) InstanceCount(ctx context.Context, component lunchpail.Component, runname string) (int, error) {
+func (backend Backend) InstanceCount(ctx context.Context, component lunchpail.Component, run queue.RunContext) (int, error) {
 	c, _, err := Client()
 	if err != nil {
 		return 0, err
@@ -17,7 +18,7 @@ func (backend Backend) InstanceCount(ctx context.Context, component lunchpail.Co
 
 	pods, err := c.CoreV1().Pods(backend.namespace).List(ctx, metav1.ListOptions{
 		FieldSelector: "status.phase=Running",
-		LabelSelector: "app.kubernetes.io/component=" + string(component) + ",app.kubernetes.io/instance=" + runname,
+		LabelSelector: "app.kubernetes.io/component=" + string(component) + ",app.kubernetes.io/instance=" + run.RunName,
 	})
 	if err != nil {
 		return 0, err

--- a/pkg/be/kubernetes/logs.go
+++ b/pkg/be/kubernetes/logs.go
@@ -42,7 +42,7 @@ func (streamer Streamer) podLogs(podName string, component lunchpail.Component, 
 // TODO port this to use client-go
 func (streamer Streamer) ComponentLogs(component lunchpail.Component, opts streamer.LogOptions) error {
 	containers := "main"
-	runSelector := ",app.kubernetes.io/instance=" + streamer.runname
+	runSelector := ",app.kubernetes.io/instance=" + streamer.run.RunName
 
 	followFlag := ""
 	if opts.Follow {

--- a/pkg/be/kubernetes/qstat.go
+++ b/pkg/be/kubernetes/qstat.go
@@ -24,7 +24,7 @@ func (streamer Streamer) streamModel(follow bool, tail int64, quiet bool, c chan
 		return err
 	}
 
-	pods, err := clientset.CoreV1().Pods(streamer.backend.namespace).List(streamer.Context, metav1.ListOptions{LabelSelector: "app.kubernetes.io/component=workstealer,app.kubernetes.io/instance=" + streamer.runname})
+	pods, err := clientset.CoreV1().Pods(streamer.backend.namespace).List(streamer.Context, metav1.ListOptions{LabelSelector: "app.kubernetes.io/component=workstealer,app.kubernetes.io/instance=" + streamer.run.RunName})
 	if err != nil {
 		return err
 	} else if len(pods.Items) == 0 {

--- a/pkg/be/kubernetes/streamer.go
+++ b/pkg/be/kubernetes/streamer.go
@@ -4,15 +4,16 @@ import (
 	"context"
 
 	"lunchpail.io/pkg/be/streamer"
+	"lunchpail.io/pkg/ir/queue"
 )
 
 type Streamer struct {
 	context.Context
-	runname string
+	run     queue.RunContext
 	backend Backend
 }
 
 // Return a streamer
-func (backend Backend) Streamer(ctx context.Context, runname string) streamer.Streamer {
-	return Streamer{ctx, runname, backend}
+func (backend Backend) Streamer(ctx context.Context, run queue.RunContext) streamer.Streamer {
+	return Streamer{ctx, run, backend}
 }

--- a/pkg/be/kubernetes/updates.go
+++ b/pkg/be/kubernetes/updates.go
@@ -136,7 +136,7 @@ func (streamer Streamer) streamPodUpdates(watcher watch.Interface, cc chan event
 }
 
 func (streamer Streamer) RunComponentUpdates(cc chan events.ComponentUpdate, cm chan events.Message) error {
-	watcher, err := streamer.startWatching(streamer.runname, streamer.backend.namespace)
+	watcher, err := streamer.startWatching(streamer.run.RunName, streamer.backend.namespace)
 	if err != nil {
 		return err
 	}

--- a/pkg/be/kubernetes/utilization.go
+++ b/pkg/be/kubernetes/utilization.go
@@ -29,7 +29,7 @@ func (streamer Streamer) startWatchingUtilization() (watch.Interface, error) {
 
 	podWatcher, err := clientset.CoreV1().Pods(streamer.backend.namespace).Watch(streamer.Context, metav1.ListOptions{
 		TimeoutSeconds: &timeoutSeconds,
-		LabelSelector:  "app.kubernetes.io/component,app.kubernetes.io/instance=" + streamer.runname,
+		LabelSelector:  "app.kubernetes.io/component,app.kubernetes.io/instance=" + streamer.run.RunName,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/be/local/files/files.go
+++ b/pkg/be/local/files/files.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"lunchpail.io/pkg/build"
+	"lunchpail.io/pkg/ir/queue"
 	"lunchpail.io/pkg/lunchpail"
 )
 
@@ -46,18 +47,18 @@ func RunsDir() (string, error) {
 	return filepath.Join(dir, "runs"), nil
 }
 
-func runDir(runname string) (string, error) {
+func runDir(run queue.RunContext) (string, error) {
 	dir, err := RunsDir()
 	if err != nil {
 		return "", err
 	}
 
 	//strings.Replace(runname, build.Name()+"-", "", 1),
-	return filepath.Join(dir, runname), nil
+	return filepath.Join(dir, run.RunName, "step", fmt.Sprintf("%d", run.Step)), nil
 }
 
-func LogDir(runname string, mkdir bool) (string, error) {
-	dir, err := runDir(runname)
+func LogDir(run queue.RunContext, mkdir bool) (string, error) {
+	dir, err := runDir(run)
 	if err != nil {
 		return "", err
 	}
@@ -75,8 +76,8 @@ func LogFileForComponent(c lunchpail.Component) string {
 	return lunchpail.ComponentShortName(c)
 }
 
-func LogsForComponent(runname string, c lunchpail.Component) (string, error) {
-	dir, err := LogDir(runname, false)
+func LogsForComponent(run queue.RunContext, c lunchpail.Component) (string, error) {
+	dir, err := LogDir(run, false)
 	if err != nil {
 		return "", err
 	}
@@ -88,8 +89,8 @@ func LogsForComponent(runname string, c lunchpail.Component) (string, error) {
 	return filepath.Join(dir, LogFileForComponent(c)+".out"), nil
 }
 
-func componentsDir(runname string) (string, error) {
-	dir, err := runDir(runname)
+func componentsDir(run queue.RunContext) (string, error) {
+	dir, err := runDir(run)
 	if err != nil {
 		return "", err
 	}
@@ -97,8 +98,8 @@ func componentsDir(runname string) (string, error) {
 	return filepath.Join(dir, "components"), nil
 }
 
-func PidfileForMain(runname string) (string, error) {
-	dir, err := componentsDir(runname)
+func PidfileForMain(run queue.RunContext) (string, error) {
+	dir, err := componentsDir(run)
 	if err != nil {
 		return "", err
 	}
@@ -114,8 +115,8 @@ func IsMainPidfile(pidfile string) bool {
 	return pidfile == "main.pid"
 }
 
-func PidfileDir(runname string) (string, error) {
-	return componentsDir(runname)
+func PidfileDir(run queue.RunContext) (string, error) {
+	return componentsDir(run)
 }
 
 func ComponentForPidfile(pidfile string) (lunchpail.Component, string, error) {
@@ -138,8 +139,8 @@ func ComponentForPidfile(pidfile string) (lunchpail.Component, string, error) {
 	}
 }
 
-func Pidfile(runname, instanceName string, c lunchpail.Component, mkdir bool) (string, error) {
-	dir, err := PidfileDir(runname)
+func Pidfile(run queue.RunContext, instanceName string, c lunchpail.Component, mkdir bool) (string, error) {
+	dir, err := PidfileDir(run)
 	if err != nil {
 		return "", err
 	}
@@ -153,8 +154,8 @@ func Pidfile(runname, instanceName string, c lunchpail.Component, mkdir bool) (s
 	return filepath.Join(dir, string(c)+"-"+instanceName+".pid"), nil
 }
 
-func QueueFile(runname string) (string, error) {
-	dir, err := runDir(runname)
+func QueueFile(run queue.RunContext) (string, error) {
+	dir, err := runDir(run)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/be/local/instancecount.go
+++ b/pkg/be/local/instancecount.go
@@ -7,12 +7,13 @@ import (
 	"strings"
 
 	"lunchpail.io/pkg/be/local/files"
+	"lunchpail.io/pkg/ir/queue"
 	"lunchpail.io/pkg/lunchpail"
 )
 
 // Number of instances of the given component for the given run
-func (backend Backend) InstanceCount(ctx context.Context, c lunchpail.Component, runname string) (int, error) {
-	dir, err := files.PidfileDir(runname)
+func (backend Backend) InstanceCount(ctx context.Context, c lunchpail.Component, run queue.RunContext) (int, error) {
+	dir, err := files.PidfileDir(run)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/be/local/queue.go
+++ b/pkg/be/local/queue.go
@@ -7,17 +7,18 @@ import (
 
 	"lunchpail.io/pkg/be/local/files"
 	"lunchpail.io/pkg/ir/llir"
+	"lunchpail.io/pkg/ir/queue"
 )
 
 // Queue properties for a given run, plus ensure access to the endpoint from this client
-func (backend Backend) AccessQueue(ctx context.Context, runname string) (endpoint, accessKeyID, secretAccessKey, bucket string, stop func(), err error) {
-	endpoint, accessKeyID, secretAccessKey, bucket, err = backend.Queue(ctx, runname)
+func (backend Backend) AccessQueue(ctx context.Context, run queue.RunContext) (endpoint, accessKeyID, secretAccessKey, bucket string, stop func(), err error) {
+	endpoint, accessKeyID, secretAccessKey, bucket, err = backend.Queue(ctx, run)
 	stop = func() {}
 	return
 }
 
-func (backend Backend) Queue(ctx context.Context, runname string) (endpoint, accessKeyID, secretAccessKey, bucket string, err error) {
-	spec, rerr := restoreContext(runname)
+func (backend Backend) Queue(ctx context.Context, run queue.RunContext) (endpoint, accessKeyID, secretAccessKey, bucket string, err error) {
+	spec, rerr := restoreContext(run)
 	if rerr != nil {
 		err = rerr
 		return
@@ -32,7 +33,7 @@ func (backend Backend) Queue(ctx context.Context, runname string) (endpoint, acc
 }
 
 func saveContext(ir llir.LLIR) error {
-	f, err := files.QueueFile(ir.RunName())
+	f, err := files.QueueFile(ir.Context.Run)
 	if err != nil {
 		return err
 	}
@@ -45,10 +46,10 @@ func saveContext(ir llir.LLIR) error {
 	return os.WriteFile(f, b, 0644)
 }
 
-func restoreContext(runname string) (llir.Context, error) {
+func restoreContext(run queue.RunContext) (llir.Context, error) {
 	var spec llir.Context
 
-	f, err := files.QueueFile(runname)
+	f, err := files.QueueFile(run)
 	if err != nil {
 		return spec, err
 	}

--- a/pkg/be/local/runs.go
+++ b/pkg/be/local/runs.go
@@ -11,6 +11,7 @@ import (
 
 	"lunchpail.io/pkg/be/local/files"
 	"lunchpail.io/pkg/be/runs"
+	"lunchpail.io/pkg/ir/queue"
 	"lunchpail.io/pkg/lunchpail"
 )
 
@@ -59,7 +60,7 @@ func (backend Backend) ListRuns(ctx context.Context, all bool) ([]runs.Run, erro
 }
 
 func isRunning(runname string) (bool, error) {
-	pidfile, err := files.PidfileForMain(runname)
+	pidfile, err := files.PidfileForMain(queue.RunContext{RunName: runname})
 	if err != nil {
 		return false, err
 	}
@@ -99,7 +100,7 @@ type Part struct {
 type Parts = map[int32]Part
 
 func partsOfRun(runname string) (Parts, error) {
-	dir, err := files.PidfileDir(runname)
+	dir, err := files.PidfileDir(queue.RunContext{RunName: runname})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/be/local/shell/spawn.go
+++ b/pkg/be/local/shell/spawn.go
@@ -17,7 +17,7 @@ import (
 )
 
 func Spawn(ctx context.Context, c llir.ShellComponent, ir llir.LLIR, logdir string, opts build.LogOptions) error {
-	pidfile, err := files.Pidfile(ir.RunName(), c.InstanceName, c.C(), true)
+	pidfile, err := files.Pidfile(ir.Context.Run, c.InstanceName, c.C(), true)
 	if err != nil {
 		return err
 	}
@@ -35,7 +35,7 @@ func Spawn(ctx context.Context, c llir.ShellComponent, ir llir.LLIR, logdir stri
 	}
 
 	if opts.Verbose {
-		fmt.Fprintf(os.Stderr, "Launching process with commandline: %s\n", command)
+		fmt.Fprintf(os.Stderr, "Launching process for component %v instance %s with commandline: %s\n", c.C(), c.InstanceName, command)
 	}
 
 	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", command)

--- a/pkg/be/local/up.go
+++ b/pkg/be/local/up.go
@@ -27,13 +27,13 @@ func (backend Backend) Up(octx context.Context, ir llir.LLIR, opts llir.Options,
 	}
 
 	// This is where component logs will go
-	logdir, err := files.LogDir(ir.RunName(), true)
+	logdir, err := files.LogDir(ir.Context.Run, true)
 	if err != nil {
 		return err
 	}
 
 	// Write a pid file to indicate the pid of this process
-	if pidfile, err := files.PidfileForMain(ir.RunName()); err != nil {
+	if pidfile, err := files.PidfileForMain(ir.Context.Run); err != nil {
 		return err
 	} else {
 		shell.WritePid(pidfile, os.Getpid())

--- a/pkg/be/target/platform.go
+++ b/pkg/be/target/platform.go
@@ -1,6 +1,9 @@
 package target
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+)
 
 type Platform string
 
@@ -24,6 +27,18 @@ func lookup(maybe string) (Platform, error) {
 	}
 
 	return "", fmt.Errorf("Unsupported target platform %s\n", maybe)
+}
+
+func FromEnv() (Platform, error) {
+	if os.Getenv("LUNCHPAIL_TARGET") != "" {
+		t, err := lookup(os.Getenv("LUNCHPAIL_TARGET"))
+		if err != nil {
+			return "", err
+		}
+		return t, nil
+	}
+
+	return "", nil
 }
 
 // String is used both by fmt.Print and by Cobra in help text

--- a/pkg/boot/io.go
+++ b/pkg/boot/io.go
@@ -2,6 +2,7 @@ package boot
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
@@ -9,27 +10,48 @@ import (
 	"lunchpail.io/pkg/be"
 	"lunchpail.io/pkg/build"
 	"lunchpail.io/pkg/ir/llir"
+	"lunchpail.io/pkg/ir/queue"
 	"lunchpail.io/pkg/runtime/builtins"
-	"lunchpail.io/pkg/runtime/queue"
-	"lunchpail.io/pkg/util"
+	s3 "lunchpail.io/pkg/runtime/queue"
 )
 
 // Behave like `cat inputs | ... > outputs`
 func catAndRedirect(ctx context.Context, inputs []string, backend be.Backend, ir llir.LLIR, opts build.LogOptions) error {
-	client, err := queue.NewS3ClientForRun(ctx, backend, ir.Context.Run.RunName)
+	client, err := s3.NewS3ClientForRun(ctx, backend, ir.Context.Run.RunName)
 	if err != nil {
 		return err
 	}
 	defer client.Stop()
 
-	if err := builtins.Cat(ctx, client.S3Client, ir.Context.Run, inputs, opts); err != nil {
-		return err
+	// either we are the first step with command line inputs (if
+	// so, "cat" them into the queue), or we are a subsequent step
+	// (in which case we need to simulate a "dispatch done")
+	if len(inputs) > 0 {
+		// "cat" the inputs into the queue
+		if opts.Verbose {
+			fmt.Fprintf(os.Stderr, "up is using 'cat' to inject %d input files\n", len(inputs))
+		}
+		if err := builtins.Cat(ctx, client.S3Client, ir.Context.Run, inputs, opts); err != nil {
+			return err
+		}
+	} else if ir.Context.Run.Step > 0 {
+		// simulate a "dispatch done"
+		if opts.Verbose {
+			fmt.Fprintln(os.Stderr, "up is simulating a dispatcher done event", os.Args)
+		}
+		if err := s3.QdoneClient(ctx, client.S3Client, ir.Context.Run, opts); err != nil {
+			return err
+		}
 	}
 
 	// TODO: backend.Wait(ir)? which would be a no-op for local
 
 	// If we aren't piped into anything, then copy out the outbox files
-	if util.StdoutIsTty() || os.Getenv("LUNCHPAIL_FORCE_TTY") != "" {
+	if ir.Context.Run.IsFinalStep {
+		// We try to place the output files in the same
+		// directory as the respective input files. TODO: this
+		// may be a fool's errand, e.g. what if a single input
+		// results in two outputs?
 		folderFor := func(output string) string {
 			inIdx := slices.IndexFunc(inputs, func(in string) bool { return filepath.Base(in) == output })
 			if inIdx >= 0 {
@@ -37,10 +59,24 @@ func catAndRedirect(ctx context.Context, inputs []string, backend be.Backend, ir
 			}
 			return "."
 		}
+		if opts.Verbose {
+			fmt.Fprintln(os.Stderr, "up is redirecting output files", os.Args)
+		}
 		if err := builtins.RedirectTo(ctx, client.S3Client, ir.Context.Run, folderFor, opts); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+// For Step > 0, we will need to simulate that a dispatch is done
+func fakeDispatch(ctx context.Context, backend be.Backend, run queue.RunContext, opts build.LogOptions) error {
+	client, err := s3.NewS3ClientForRun(ctx, backend, run.RunName)
+	if err != nil {
+		return err
+	}
+	defer client.Stop()
+
+	return s3.QdoneClient(ctx, client.S3Client, run, opts)
 }

--- a/pkg/build/breadcrumbs.go
+++ b/pkg/build/breadcrumbs.go
@@ -30,6 +30,16 @@ func Name() string {
 	if n == "" {
 		n = strings.TrimSpace(name)
 	}
+
+	// avoid complications with downstream shell executions
+	n = strings.Replace(n, "<", "", -1)
+	n = strings.Replace(n, ">", "", -1)
+	n = strings.Replace(n, "|", "", -1)
+	n = strings.Replace(n, ";", "", -1)
+	n = strings.Replace(n, "$", "", -1)
+	n = strings.Replace(n, "{", "", -1)
+	n = strings.Replace(n, "}", "", -1)
+
 	return n
 }
 

--- a/pkg/fe/transformer/api/workstealer/transpile.go
+++ b/pkg/fe/transformer/api/workstealer/transpile.go
@@ -16,9 +16,10 @@ func transpile(ctx llir.Context, opts build.LogOptions) (hlir.Application, error
 
 	app.Spec.Image = fmt.Sprintf("%s/%s/lunchpail:%s", lunchpail.ImageRegistry, lunchpail.ImageRepo, lunchpail.Version())
 	app.Spec.Role = "workstealer"
-	app.Spec.Command = fmt.Sprintf("$LUNCHPAIL_EXE component workstealer run --verbose=%v --debug=%v",
+	app.Spec.Command = fmt.Sprintf("$LUNCHPAIL_EXE component workstealer run --verbose=%v --debug=%v --self-destruct=%v",
 		opts.Verbose,
 		opts.Debug,
+		ctx.Run.IsFinalStep,
 	)
 
 	app.Spec.Env = hlir.Env{}

--- a/pkg/ir/queue/paths.go
+++ b/pkg/ir/queue/paths.go
@@ -13,7 +13,7 @@ const (
 	FinishedWithSucceeded      = "lunchpail/run/{{.RunName}}/step/{{.Step}}/succeeded/pool/{{.PoolName}}/worker/{{.WorkerName}}/{{.Task}}"
 	FinishedWithFailed         = "lunchpail/run/{{.RunName}}/step/{{.Step}}/failed/pool/{{.PoolName}}/worker/{{.WorkerName}}/{{.Task}}"
 	WorkerKillFile             = "lunchpail/run/{{.RunName}}/step/{{.Step}}/killfiles/pool/{{.PoolName}}/worker/{{.WorkerName}}"
-	AllDoneMarker              = "lunchpail/run/{{.RunName}}/step/{{.Step}}/marker/alldone"
+	AllDoneMarker              = "lunchpail/run/{{.RunName}}/alldone" // Note: not step-specific!
 	DispatcherDoneMarker       = "lunchpail/run/{{.RunName}}/step/{{.Step}}/marker/dispatcherdone"
 	WorkerAliveMarker          = "lunchpail/run/{{.RunName}}/step/{{.Step}}/marker/alive/pool/{{.PoolName}}/worker/{{.WorkerName}}"
 	WorkerDeadMarker           = "lunchpail/run/{{.RunName}}/step/{{.Step}}/marker/dead/pool/{{.PoolName}}/worker/{{.WorkerName}}"

--- a/pkg/ir/queue/queue.go
+++ b/pkg/ir/queue/queue.go
@@ -13,3 +13,8 @@ func (spec Spec) UpdateEndpoint(endpoint string) Spec {
 	spec.Endpoint = endpoint
 	return spec
 }
+
+func (spec Spec) NoAuto() Spec {
+	spec.Auto = false
+	return spec
+}

--- a/pkg/ir/queue/run.go
+++ b/pkg/ir/queue/run.go
@@ -11,6 +11,9 @@ type RunContext struct {
 	// Which step of the run are we participating in?
 	Step int
 
+	// Are we the final step of a pipeline?
+	IsFinalStep bool
+
 	// Which worker pool are we part of?
 	PoolName string
 
@@ -19,4 +22,14 @@ type RunContext struct {
 
 	// Which task are we processing?
 	Task string
+}
+
+func (r RunContext) IncrStep() RunContext {
+	r.Step++
+	return r
+}
+
+func (r RunContext) AsFinalStep(isFinalStep bool) RunContext {
+	r.IsFinalStep = isFinalStep
+	return r
 }

--- a/pkg/observe/cpu/ui.go
+++ b/pkg/observe/cpu/ui.go
@@ -9,6 +9,7 @@ import (
 	"lunchpail.io/pkg/be"
 	"lunchpail.io/pkg/be/events/utilization"
 	"lunchpail.io/pkg/be/runs/util"
+	"lunchpail.io/pkg/ir/queue"
 	"lunchpail.io/pkg/observe/status"
 )
 
@@ -29,7 +30,7 @@ func UI(ctx context.Context, runnameIn string, backend be.Backend, opts CpuOptio
 	c := make(chan utilization.Model)
 	group.Go(func() error {
 		defer close(c)
-		return backend.Streamer(sctx, runname).Utilization(c, opts.IntervalSeconds)
+		return backend.Streamer(sctx, queue.RunContext{RunName: runname}).Utilization(c, opts.IntervalSeconds)
 	})
 
 	for model := range c {

--- a/pkg/observe/logs.go
+++ b/pkg/observe/logs.go
@@ -9,6 +9,7 @@ import (
 	"lunchpail.io/pkg/be"
 	"lunchpail.io/pkg/be/runs/util"
 	"lunchpail.io/pkg/be/streamer"
+	"lunchpail.io/pkg/ir/queue"
 	"lunchpail.io/pkg/lunchpail"
 	"lunchpail.io/pkg/observe/colors"
 )
@@ -33,7 +34,7 @@ func Logs(ctx context.Context, runnameIn string, backend be.Backend, opts LogsOp
 	useComponentPrefix := len(opts.Components) > 1
 
 	group, _ := errgroup.WithContext(ctx)
-	s := backend.Streamer(ctx, runname)
+	s := backend.Streamer(ctx, queue.RunContext{RunName: runname})
 	for _, component := range opts.Components {
 		group.Go(func() error {
 			var prefix streamer.LinePrefixFunction

--- a/pkg/observe/qstat/qlast.go
+++ b/pkg/observe/qstat/qlast.go
@@ -11,6 +11,7 @@ import (
 	"lunchpail.io/pkg/be"
 	"lunchpail.io/pkg/be/events/qstat"
 	"lunchpail.io/pkg/be/runs/util"
+	"lunchpail.io/pkg/ir/queue"
 )
 
 type QlastOptions struct {
@@ -27,7 +28,7 @@ func Qlast(ctx context.Context, marker, opt string, backend be.Backend, opts Qla
 	group, _ := errgroup.WithContext(ctx)
 	group.Go(func() error {
 		defer close(c)
-		return backend.Streamer(ctx, runname).QueueStats(c, qstat.Options{Tail: int64(1000)})
+		return backend.Streamer(ctx, queue.RunContext{RunName: runname}).QueueStats(c, qstat.Options{Tail: int64(1000)})
 	})
 
 	var lastmodel qstat.Model

--- a/pkg/observe/qstat/ui.go
+++ b/pkg/observe/qstat/ui.go
@@ -14,6 +14,7 @@ import (
 	"lunchpail.io/pkg/be"
 	"lunchpail.io/pkg/be/events/qstat"
 	"lunchpail.io/pkg/be/runs/util"
+	"lunchpail.io/pkg/ir/queue"
 )
 
 type Options = qstat.Options
@@ -29,7 +30,7 @@ func UI(ctx context.Context, runnameIn string, backend be.Backend, opts Options)
 	group, _ := errgroup.WithContext(ctx)
 	group.Go(func() error {
 		defer close(c)
-		return backend.Streamer(ctx, runname).QueueStats(c, opts)
+		return backend.Streamer(ctx, queue.RunContext{RunName: runname}).QueueStats(c, opts)
 	})
 
 	purple := lipgloss.Color("99")

--- a/pkg/observe/status/stream.go
+++ b/pkg/observe/status/stream.go
@@ -11,6 +11,7 @@ import (
 	"lunchpail.io/pkg/be/events/qstat"
 	"lunchpail.io/pkg/be/events/utilization"
 	"lunchpail.io/pkg/build"
+	"lunchpail.io/pkg/ir/queue"
 	"lunchpail.io/pkg/lunchpail"
 )
 
@@ -23,7 +24,7 @@ func StatusStreamer(ctx context.Context, run string, backend be.Backend, verbose
 	model.LastNMessages = ring.New(nLoglinesMax)
 
 	errgroup, sctx := errgroup.WithContext(ctx)
-	streamer := backend.Streamer(sctx, run)
+	streamer := backend.Streamer(sctx, queue.RunContext{RunName: run})
 
 	qc := make(chan qstat.Model)
 	errgroup.Go(func() error {

--- a/pkg/runtime/builtins/cat.go
+++ b/pkg/runtime/builtins/cat.go
@@ -39,10 +39,11 @@ func CatClient(ctx context.Context, backend be.Backend, run queue.RunContext, in
 func CatApp() hlir.HLIR {
 	app := hlir.NewApplication("cat")
 	app.Spec.Role = "worker"
-	app.Spec.Command = "/bin/sh -c ./main.sh"
+	app.Spec.Command = "./main.sh"
 	app.Spec.Image = "docker.io/alpine:3"
 	app.Spec.Code = []hlir.Code{
-		hlir.Code{Name: "main.sh", Source: "echo hi"},
+		hlir.Code{Name: "main.sh", Source: `#!/bin/sh
+mv $1 $2`},
 	}
 
 	return hlir.HLIR{

--- a/pkg/runtime/queue/client.go
+++ b/pkg/runtime/queue/client.go
@@ -10,6 +10,7 @@ import (
 
 	"lunchpail.io/pkg/be"
 	"lunchpail.io/pkg/be/runs/util"
+	"lunchpail.io/pkg/ir/queue"
 )
 
 type S3Client struct {
@@ -75,7 +76,7 @@ func NewS3ClientForRun(ctx context.Context, backend be.Backend, runname string) 
 		runname = run.Name
 	}
 
-	endpoint, accessKeyId, secretAccessKey, bucket, stop, err := backend.AccessQueue(ctx, runname)
+	endpoint, accessKeyId, secretAccessKey, bucket, stop, err := backend.AccessQueue(ctx, queue.RunContext{RunName: runname})
 	if err != nil {
 		return S3ClientStop{}, err
 	}

--- a/pkg/runtime/queue/qdone.go
+++ b/pkg/runtime/queue/qdone.go
@@ -15,6 +15,10 @@ func QdoneClient(ctx context.Context, c S3Client, run queue.RunContext, opts bui
 		fmt.Fprintf(os.Stderr, "Done with dispatching\n")
 	}
 
+	if err := c.Mkdirp(run.Bucket); err != nil {
+		return err
+	}
+
 	return c.Touch(run.Bucket, run.AsFile(queue.DispatcherDoneMarker))
 }
 

--- a/pkg/runtime/worker/prestop.go
+++ b/pkg/runtime/worker/prestop.go
@@ -23,7 +23,7 @@ func PreStop(ctx context.Context, opts Options) error {
 	client.Touch(opts.RunContext.Bucket, opts.RunContext.AsFile(queue.WorkerDeadMarker))
 
 	if opts.LogOptions.Verbose {
-		fmt.Printf("This worker is shutting down %s\n", os.Getenv("LUNCHPAIL_POD_NAME"))
+		fmt.Fprintf(os.Stderr, "This worker is shutting down pool=%s worker=%s\n", opts.RunContext.PoolName, opts.RunContext.WorkerName)
 	}
 
 	return nil

--- a/pkg/runtime/worker/process-task.go
+++ b/pkg/runtime/worker/process-task.go
@@ -36,10 +36,6 @@ func (p taskProcessor) process(task string) error {
 	if task != "" {
 		task = filepath.Base(task)
 
-		if opts.LogOptions.Verbose {
-			fmt.Fprintf(os.Stderr, "Worker starting task %s\n", task)
-		}
-
 		a := opts.RunContext.ForTask(task)
 		in := a.AsFile(queue.AssignedAndPending)
 		inprogress := a.AsFile(queue.AssignedAndProcessing)
@@ -54,6 +50,10 @@ func (p taskProcessor) process(task string) error {
 		localoutbox := filepath.Join(p.localdir, "outbox", task)
 		localstdout := localprocessing + ".stdout"
 		localstderr := localprocessing + ".stderr"
+
+		if opts.LogOptions.Verbose {
+			fmt.Fprintf(os.Stderr, "Worker starting task %s with f(%s,%s)\n", task, localprocessing, localoutbox)
+		}
 
 		// Currently, we don't need localoutbox to be a
 		// directory. This is future-proofing for handling

--- a/pkg/runtime/workstealer/assess.go
+++ b/pkg/runtime/workstealer/assess.go
@@ -47,14 +47,6 @@ func (c client) assignNewTaskToWorker(task string, worker Worker) error {
 	return c.moveToWorkerInbox(task, worker)
 }
 
-type Box string
-
-const (
-	Inbox      = "inbox"
-	Processing = "processing"
-	Outbox     = "outbox"
-)
-
 // A Worker has died. Unassign this task that it owns
 func (c client) moveAssignedTaskBackToUnassigned(task string, worker Worker) error {
 	inWorkerFilePath := c.RunContext.ForPool(worker.pool).ForWorker(worker.name).ForTask(task).AsFile(queue.AssignedAndPending)

--- a/pkg/runtime/workstealer/model.go
+++ b/pkg/runtime/workstealer/model.go
@@ -34,12 +34,13 @@ type Model struct {
 	DispatcherDone bool
 
 	UnassignedTasks []string
-	LiveWorkers     []Worker
-	DeadWorkers     []Worker
+	OutboxTasks     []string
+
+	LiveWorkers []Worker
+	DeadWorkers []Worker
 
 	AssignedTasks   []AssignedTask
 	ProcessingTasks []AssignedTask
-	OutboxTasks     []AssignedTask
 
 	SuccessfulTasks []AssignedTask
 	FailedTasks     []AssignedTask

--- a/pkg/runtime/workstealer/report.go
+++ b/pkg/runtime/workstealer/report.go
@@ -18,6 +18,7 @@ func (model Model) report(c client) error {
 	fmt.Fprintf(writer, "lunchpail.io\tdispatcherDone\t%v\t\t\t\t\t%s\n", model.DispatcherDone, c.RunContext.RunName)
 	fmt.Fprintf(writer, "lunchpail.io\tassigned\t%d\t\t\t\t\t%s\n", len(model.AssignedTasks), c.RunContext.RunName)
 	fmt.Fprintf(writer, "lunchpail.io\tprocessing\t\t%d\t\t\t\t%s\n", len(model.ProcessingTasks), c.RunContext.RunName)
+	fmt.Fprintf(writer, "lunchpail.io\toutbox\t\t\t%d\t\t\t%s\n", len(model.OutboxTasks), c.RunContext.RunName)
 	fmt.Fprintf(writer, "lunchpail.io\tdone\t\t\t%d\t%d\t\t%s\n", len(model.SuccessfulTasks), len(model.FailedTasks), c.RunContext.RunName)
 	fmt.Fprintf(writer, "lunchpail.io\tliveworkers\t%d\t\t\t\t\t%s\n", len(model.LiveWorkers), c.RunContext.RunName)
 	fmt.Fprintf(writer, "lunchpail.io\tdeadworkers\t%d\t\t\t\t\t%s\n", len(model.DeadWorkers), c.RunContext.RunName)

--- a/pkg/runtime/workstealer/run.go
+++ b/pkg/runtime/workstealer/run.go
@@ -14,7 +14,12 @@ import (
 )
 
 type Options struct {
+	// If we need to resort to polling of S3, this is the polling interval we will use
 	PollingInterval int
+
+	// Automatically tear down the run when all output has been consumed?
+	SelfDestruct bool
+
 	build.LogOptions
 }
 
@@ -41,13 +46,14 @@ func Run(ctx context.Context, run queue.RunContext, opts Options) error {
 	fmt.Fprintln(os.Stderr, "Workstealer starting")
 	if opts.Verbose {
 		fmt.Fprintf(os.Stderr, "Run: %v\n", run)
+		fmt.Fprintf(os.Stderr, "PathPatterns: %v\n", c.pathPatterns.outboxTask.String())
 		printenv()
 	}
 
 	done := false
 	for !done {
 		err = once(ctx, c, opts)
-		if err == nil || !strings.Contains(err.Error(), "connection refused") {
+		if err == nil || isFatal(err) {
 			done = true
 		} else {
 			// wait for s3 to be ready
@@ -57,8 +63,15 @@ func Run(ctx context.Context, run queue.RunContext, opts Options) error {
 
 	// Drop a final breadcrumb indicating we are ready to tear
 	// down all associated resources
-	if err := s3.Touch(c.RunContext.Bucket, c.RunContext.AsFile(queue.AllDoneMarker)); err != nil {
-		fmt.Fprintf(os.Stderr, "Unable to touch AllDone file\n%v\n", err)
+	if opts.SelfDestruct {
+		if opts.Verbose {
+			fmt.Fprintf(os.Stderr, "Instructing the run to self-destruct bucket=%s file=%s\n", c.RunContext.Bucket, c.RunContext.AsFile(queue.AllDoneMarker))
+		}
+		if err := s3.Touch(c.RunContext.Bucket, c.RunContext.AsFile(queue.AllDoneMarker)); err != nil {
+			fmt.Fprintf(os.Stderr, "Unable to touch AllDone file\n%v\n", err)
+		}
+	} else if opts.Verbose {
+		fmt.Fprintln(os.Stderr, "*Not* instructing the run to self-destruct")
 	}
 
 	util.SleepBeforeExit()
@@ -67,22 +80,31 @@ func Run(ctx context.Context, run queue.RunContext, opts Options) error {
 	return err
 }
 
+func isFatal(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "unexpected EOF")
+}
+
 func once(ctx context.Context, c client, opts Options) error {
 	if err := c.s3.Mkdirp(c.RunContext.Bucket); err != nil {
 		return err
 	}
 
 	if opts.Verbose {
-		fmt.Fprintf(os.Stderr, "Listen bucket=%s path=%s\n", c.RunContext.Bucket, c.RunContext.ListenPrefix())
+		fmt.Fprintf(os.Stderr, "Listen bucket=%s path=%s path2=%s\n", c.RunContext.Bucket, c.RunContext.ListenPrefix(), c.RunContext.AsFile(queue.AssignedAndFinished))
 	}
-	objs, errs := c.s3.Listen(c.RunContext.Bucket, c.RunContext.ListenPrefix(), "", true)
+	step0Objects, step0Errs := c.s3.Listen(c.RunContext.Bucket, c.RunContext.ListenPrefix(), "", true)
+	step1Objects, step1Errs := c.s3.Listen(c.RunContext.Bucket, c.RunContext.AsFile(queue.AssignedAndFinished), "", true)
 	defer c.s3.StopListening(c.RunContext.Bucket)
 
 	done := false
 	for !done {
 		select {
-		case err := <-errs:
-			if err != nil && strings.Contains(err.Error(), "connection refused") {
+		case err := <-step1Errs:
+			if isFatal(err) {
+				return err
+			}
+		case err := <-step0Errs:
+			if isFatal(err) {
 				return err
 			}
 
@@ -90,15 +112,13 @@ func once(ctx context.Context, c client, opts Options) error {
 
 			// sleep for a bit
 			time.Sleep(time.Duration(opts.PollingInterval) * time.Second)
-		case obj := <-objs:
-			// TODO update model incrementally rather than
-			// re-fetching and re-parsing the entire model
-			// every time there is a single change
-			if strings.Contains(obj, "/logs/") {
-				continue
-			}
 
-			if c.LogOptions.Debug {
+		case obj := <-step0Objects:
+			if c.LogOptions.Verbose {
+				fmt.Fprintf(os.Stderr, "Got push notification object=%s\n", obj)
+			}
+		case obj := <-step1Objects:
+			if c.LogOptions.Verbose {
 				fmt.Fprintf(os.Stderr, "Got push notification object=%s\n", obj)
 			}
 		case <-ctx.Done():

--- a/pkg/util/term.go
+++ b/pkg/util/term.go
@@ -10,5 +10,5 @@ func StdinIsTty() bool {
 }
 
 func StdoutIsTty() bool {
-	return term.IsTerminal(int(os.Stdout.Fd()))
+	return term.IsTerminal(int(os.Stdout.Fd())) || os.Getenv("LUNCHPAIL_FORCE_TTY") != ""
 }


### PR DESCRIPTION
This includes a variety of fixes to improve support for multi-step pipelines. Including avoiding stages overwriting eachother's log files for the local backend.

Updates workstealer to self-destruct only in last step

Fixes cat builtin to actually cat...