### PR TITLE
fix: needs python to run in K8; backend agnostic rqmts install

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,9 @@ jobs:
           - ./tests/bin/ci.sh -i 'test7(b.*|c.*|d.*|e.*|g.*|h.*)' 
           - ./tests/bin/ci.sh -i 'test7f.*'
           - ./tests/bin/ci.sh -i 'test8.*'
-          - ./tests/bin/ci.sh -i 'python.*'
+          - ./tests/bin/ci.sh -i 'python-code.*'
+          - ./tests/bin/ci.sh -i 'python-language.*'
+          - ./tests/bin/ci.sh -i 'python-universal.*'
           - ./tests/bin/go.sh
           - ./tests/bin/pipelines.sh
         os: [ubuntu-latest]

--- a/cmd/subcommands/needs/python.go
+++ b/cmd/subcommands/needs/python.go
@@ -11,16 +11,16 @@ import (
 )
 
 func Python() *cobra.Command {
-	var requirementsPath string
+	var requirements string
 	cmd := &cobra.Command{
-		Use:   "python <version> [-r /path/to/requirements.txt]",
+		Use:   "python <version> [-r base64EncodedRequirements]",
 		Short: "Install python environment",
 		Long:  "Install python environment",
 		Args:  cobra.MatchAll(cobra.MaximumNArgs(1), cobra.OnlyValidArgs),
 	}
 
 	logOpts := options.AddLogOptions(cmd)
-	cmd.Flags().StringVarP(&requirementsPath, "requirements", "r", requirementsPath, "Install from the given requirements file")
+	cmd.Flags().StringVarP(&requirements, "requirements", "r", requirements, "Install the given requirements")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		version := "latest"
@@ -28,7 +28,7 @@ func Python() *cobra.Command {
 			version = args[0]
 		}
 
-		out, err := needs.InstallPython(context.Background(), version, requirementsPath, needs.Options{LogOptions: *logOpts})
+		out, err := needs.InstallPython(context.Background(), version, requirements, needs.Options{LogOptions: *logOpts})
 		if err != nil {
 			return err
 		}

--- a/pkg/fe/transformer/api/shell/lower.go
+++ b/pkg/fe/transformer/api/shell/lower.go
@@ -1,8 +1,8 @@
 package shell
 
 import (
+	"encoding/base64"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strconv"
 
@@ -43,22 +43,12 @@ func LowerAsComponent(buildName string, ctx llir.Context, app hlir.Application, 
 	app.Spec.Env["LUNCHPAIL_QUEUE_BUCKET"] = ctx.Queue.Bucket
 
 	for _, needs := range app.Spec.Needs {
-		var file *os.File
-		var err error
 		var req string
 
 		if needs.Requirements != "" {
-			file, err = os.CreateTemp("", "requirements.txt")
-			if err != nil {
-				return nil, err
-			}
-
-			if err := os.WriteFile(file.Name(), []byte(needs.Requirements), 0644); err != nil {
-				return nil, err
-			}
-			req = "--requirements " + file.Name()
+			req = "--requirements " + base64.StdEncoding.EncodeToString([]byte(needs.Requirements))
 			if opts.Log.Verbose {
-				fmt.Printf("Setting requirements in %s", file.Name())
+				fmt.Printf("Setting requirements for needs \n")
 			}
 		}
 

--- a/pkg/runtime/needs/python.go
+++ b/pkg/runtime/needs/python.go
@@ -6,7 +6,7 @@ import (
 	"os/exec"
 )
 
-func InstallPython(ctx context.Context, version string, requirementsPath string, opts Options) (string, error) {
+func InstallPython(ctx context.Context, version string, requirements string, opts Options) (string, error) {
 	if _, err := exec.LookPath("python3"); err != nil {
 		if errors.Is(err, exec.ErrNotFound) {
 			if err := installPython(ctx, version, opts.Verbose); err != nil {
@@ -15,8 +15,8 @@ func InstallPython(ctx context.Context, version string, requirementsPath string,
 		}
 		return "", err
 	}
-	if requirementsPath != "" {
-		return requirementsInstall(ctx, requirementsPath, opts.Verbose)
+	if requirements != "" {
+		return requirementsInstall(ctx, requirements, opts.Verbose)
 	}
 	return "", nil
 }

--- a/tests/bin/run.sh
+++ b/tests/bin/run.sh
@@ -119,7 +119,6 @@ then
 
     ${handler-waitForIt} ${deployname:-$testname} ${namespace} $api "${expected[@]}"
     EC=$?
-    undeploy $testname $deployname
 
     if [[ $EC != 0 ]]
     then exit $EC
@@ -128,6 +127,8 @@ then
     if [[ -e "$1"/post.sh ]]
     then TEST_NAME=$testname "$1"/post.sh $namespace
     fi
+
+    undeploy $testname $deployname
 
     # clean up python venvs if we are in travis or github actions
     if [[ -n "$CI" ]] && [[ -d "$1"/.venv ]]

--- a/tests/tests/python-code-code-quality/target
+++ b/tests/tests/python-code-code-quality/target
@@ -1,1 +1,0 @@
-../python-language-pii-redactor/target

--- a/tests/tests/python-code-code2parquet/target
+++ b/tests/tests/python-code-code2parquet/target
@@ -1,1 +1,1 @@
-../python-language-pii-redactor/target
+local

--- a/tests/tests/python-language-doc-chunk/target
+++ b/tests/tests/python-language-doc-chunk/target
@@ -1,1 +1,0 @@
-../python-language-pii-redactor/target

--- a/tests/tests/python-language-doc-quality/target
+++ b/tests/tests/python-language-doc-quality/target
@@ -1,1 +1,1 @@
-../python-language-pii-redactor/target
+local

--- a/tests/tests/python-language-html2parquet/target
+++ b/tests/tests/python-language-html2parquet/target
@@ -1,1 +1,0 @@
-../python-language-pii-redactor/target

--- a/tests/tests/python-language-lang-id/target
+++ b/tests/tests/python-language-lang-id/target
@@ -1,1 +1,1 @@
-../python-language-pii-redactor/target
+local

--- a/tests/tests/python-language-pdf2parquet/target
+++ b/tests/tests/python-language-pdf2parquet/target
@@ -1,1 +1,1 @@
-../python-language-pii-redactor/target
+local

--- a/tests/tests/python-language-text-encoder/target
+++ b/tests/tests/python-language-text-encoder/target
@@ -1,1 +1,1 @@
-../python-language-pii-redactor/target
+local

--- a/tests/tests/python-universal-doc-id/target
+++ b/tests/tests/python-universal-doc-id/target
@@ -1,1 +1,0 @@
-../python-universal-tokenization/target

--- a/tests/tests/python-universal-ededup/target
+++ b/tests/tests/python-universal-ededup/target
@@ -1,1 +1,0 @@
-../python-language-pii-redactor/target

--- a/tests/tests/python-universal-filter/target
+++ b/tests/tests/python-universal-filter/target
@@ -1,1 +1,0 @@
-../python-language-pii-redactor/target

--- a/tests/tests/python-universal-resize/target
+++ b/tests/tests/python-universal-resize/target
@@ -1,1 +1,0 @@
-../python-language-pii-redactor/target

--- a/tests/tests/python-universal-tokenization/target
+++ b/tests/tests/python-universal-tokenization/target
@@ -1,1 +1,0 @@
-../python-language-pii-redactor/target


### PR DESCRIPTION
Fixes #430 

Tests that run on target=kubernetes using Datasets restricted to `local` target until writeBlobsToWorkdir is implemented for K8. Some other tests also running on local only due to other known errors like large model, etc