### PR TITLE
test: add1 pipeline tests

### DIFF
--- a/cmd/subcommands/cat.go
+++ b/cmd/subcommands/cat.go
@@ -10,14 +10,15 @@ import (
 	"lunchpail.io/cmd/options"
 	"lunchpail.io/pkg/be"
 	"lunchpail.io/pkg/boot"
+	"lunchpail.io/pkg/ir/hlir"
 	"lunchpail.io/pkg/runtime/builtins"
 )
 
-func init() {
+func initBuiltin(appFn func() hlir.HLIR, use string, short string) {
 	cmd := &cobra.Command{
-		Use:     "cat input1 [input2 ...]",
+		Use:     use,
 		GroupID: dataGroup.ID,
-		Short:   "Inject one or more files into a pipeline execution",
+		Short:   short,
 		Args:    cobra.MatchAll(cobra.OnlyValidArgs),
 	}
 
@@ -33,8 +34,13 @@ func init() {
 			return err
 		}
 
-		return boot.UpHLIR(ctx, backend, builtins.CatApp(), boot.UpOptions{BuildOptions: *buildOpts, Inputs: args})
+		return boot.UpHLIR(ctx, backend, appFn(), boot.UpOptions{BuildOptions: *buildOpts, Inputs: args})
 	}
 
 	rootCmd.AddCommand(cmd)
+}
+
+func init() {
+	initBuiltin(builtins.CatApp, "cat [input1 input2 ...]", "Inject one or more files into a pipeline execution")
+	initBuiltin(builtins.Add1App, "add1 [input1 input2 ...]", "Increment the content of each file by 1")
 }

--- a/pkg/runtime/builtins/add1.go
+++ b/pkg/runtime/builtins/add1.go
@@ -1,0 +1,21 @@
+package builtins
+
+import (
+	"lunchpail.io/pkg/ir/hlir"
+)
+
+func Add1App() hlir.HLIR {
+	app := hlir.NewApplication("add1")
+	app.Spec.Role = "worker"
+	app.Spec.Command = "./main.sh"
+	app.Spec.Image = "docker.io/alpine:3"
+	app.Spec.Code = []hlir.Code{
+		hlir.Code{Name: "main.sh", Source: `#!/bin/sh
+printf '%d' $((1+$(cat $1))) > $2`},
+	}
+
+	return hlir.HLIR{
+		Applications: []hlir.Application{app},
+		WorkerPools:  []hlir.WorkerPool{hlir.NewPool("add1", 1)},
+	}
+}


### PR DESCRIPTION
This adds `add1 | add1 | add1` pipeline tests.

This adds an `add1` command... until we have support for a `run -e` to allow for ad-hoc command line worker functions, i’ll add an add1 builtin (alongside the cat builtin) to help with tests/demos