### PR TITLE
fix: on failure loitering 'minio server' processes may remain

### DIFF
--- a/tests/bin/pipelines.sh
+++ b/tests/bin/pipelines.sh
@@ -50,6 +50,16 @@ function start {
     echo -n "$(tput dim)"
 }
 
+function noLoitering {
+    local which="$1"
+    if [[ -n "$CI" ]]
+    then if [[ 0 = $(ps | grep "$which" | grep -v grep | wc -l | xargs) ]]
+         then echo "✅ PASS no loitering '$which'"
+         else echo "❌ FAIL loitering '$which' process" && return 1
+         fi
+    fi
+}
+
 function validate {
     echo -n "$(tput sgr0)"
     local actual_ec=$1
@@ -83,6 +93,10 @@ function validate {
     fi
 
     rm -f "$actual"
+
+    # validate no loitering processes remain
+    noLoitering 'minio server'
+    noLoitering 'worker run'
 }
 
 lpcat="$lp cat $VERBOSE"


### PR DESCRIPTION
This updates the local backend to install the spawned processes in a process group, and monitors for context cancellation. Upon cancellation, it kills the process group.

On its own, Go seems only to kill the top of the process tree upon context cancellation. Sigh.