### PR TITLE
fix: stderr output of failing tasks was not being reported

### DIFF
--- a/pkg/ir/queue/as.go
+++ b/pkg/ir/queue/as.go
@@ -33,6 +33,6 @@ func (run RunContext) AsFile(path Path) string {
 
 // As with AsFile() but returning the enclosing directory (i.e. not
 // specific to a pool, a worker, or a task)
-func (run RunContext) AsDir(path Path) string {
+func (run RunContext) AsFileForAnyWorker(path Path) string {
 	return filepath.Dir(filepath.Dir(run.ForPool("").ForWorker("").ForTask("").AsFile(path)))
 }

--- a/pkg/ir/queue/for.go
+++ b/pkg/ir/queue/for.go
@@ -27,5 +27,5 @@ func (run RunContext) ForObject(path Path, object string) (RunContext, error) {
 	if len(match) != 4 {
 		return run, fmt.Errorf("ForObjectTask bad match %s %v", object, match)
 	}
-	return run.ForPool(match[1]).ForWorker(match[2]).ForTask(match[1]), nil
+	return run.ForPool(match[1]).ForWorker(match[2]).ForTask(match[3]), nil
 }

--- a/pkg/runtime/queue/wait.go
+++ b/pkg/runtime/queue/wait.go
@@ -123,7 +123,7 @@ func (s3 S3Client) StopListening(bucket string) error {
 // Wait for the given enqueued task to appear in the outbox
 func (c S3Client) WaitForCompletion(run queue.RunContext, task string, verbose bool) (int, error) {
 	run = run.ForTask(task)
-	codesDir := run.AsDir(queue.FinishedWithCode)
+	codesDir := run.AsFileForAnyWorker(queue.FinishedWithCode)
 
 	if verbose {
 		fmt.Fprintf(os.Stderr, "Waiting for task completion %s -> %s\n", task, codesDir)


### PR DESCRIPTION
This was due to using the wrong path for Failed files.