### PR TITLE
test: pin pyarrow<18

### DIFF
--- a/tests/tests/python-code-code-quality/pail/data/requirements.txt
+++ b/tests/tests/python-code-code-quality/pail/data/requirements.txt
@@ -1,4 +1,6 @@
 bs4==0.0.2
 transformers==4.38.2
 
-pyarrow
+# we can probably update to 18+, but we will have to re-generate expected output as pyarrow 18 seems to have resulted in a binary format change
+pyarrow<18
+

--- a/tests/tests/python-code-code2parquet/pail/data/requirements.txt
+++ b/tests/tests/python-code-code2parquet/pail/data/requirements.txt
@@ -1,4 +1,6 @@
 parameterized
 pandas
 
-pyarrow
+# we can probably update to 18+, but we will have to re-generate expected output as pyarrow 18 seems to have resulted in a binary format change
+pyarrow<18
+

--- a/tests/tests/python-code-header-cleanser/pail/data/requirements.txt
+++ b/tests/tests/python-code-header-cleanser/pail/data/requirements.txt
@@ -1,5 +1,7 @@
 data-prep-toolkit==0.2.2.dev1
 scancode-toolkit ; platform_system != 'Darwin'
 
-pyarrow
+# we can probably update to 18+, but we will have to re-generate expected output as pyarrow 18 seems to have resulted in a binary format change
+pyarrow<18
+
 setuptools

--- a/tests/tests/python-language-doc-chunk/pail/data/requirements.txt
+++ b/tests/tests/python-language-doc-chunk/pail/data/requirements.txt
@@ -1,4 +1,6 @@
 docling-core==1.3.0
 llama-index-core>=0.11.0,<0.12.0
 
-pyarrow
+# we can probably update to 18+, but we will have to re-generate expected output as pyarrow 18 seems to have resulted in a binary format change
+pyarrow<18
+

--- a/tests/tests/python-language-doc-quality/pail/data/requirements.txt
+++ b/tests/tests/python-language-doc-quality/pail/data/requirements.txt
@@ -1,1 +1,3 @@
-pyarrow
+# we can probably update to 18+, but we will have to re-generate expected output as pyarrow 18 seems to have resulted in a binary format change
+pyarrow<18
+

--- a/tests/tests/python-language-html2parquet/pail/data/requirements.txt
+++ b/tests/tests/python-language-html2parquet/pail/data/requirements.txt
@@ -1,4 +1,6 @@
 trafilatura==1.12.2
 lxml-html-clean==0.2.2
 
-pyarrow
+# we can probably update to 18+, but we will have to re-generate expected output as pyarrow 18 seems to have resulted in a binary format change
+pyarrow<18
+

--- a/tests/tests/python-language-lang-id/pail/data/requirements.txt
+++ b/tests/tests/python-language-lang-id/pail/data/requirements.txt
@@ -6,4 +6,7 @@ fasttext-wheel==0.9.2
 langcodes==3.3.0
 huggingface-hub >= 0.21.4, <1.0.0
 numpy==1.26.4
-pyarrow
+
+# we can probably update to 18+, but we will have to re-generate expected output as pyarrow 18 seems to have resulted in a binary format change
+pyarrow<18
+

--- a/tests/tests/python-language-pdf2parquet/pail/data/requirements.txt
+++ b/tests/tests/python-language-pdf2parquet/pail/data/requirements.txt
@@ -4,4 +4,5 @@ deepsearch-glm==0.21.0
 docling==1.11.0
 filetype >=1.2.0, <2.0.0
 
-pyarrow
+# we can probably update to 18+, but we will have to re-generate expected output as pyarrow 18 seems to have resulted in a binary format change
+pyarrow<18

--- a/tests/tests/python-language-pii-redactor/pail/data/requirements.txt
+++ b/tests/tests/python-language-pii-redactor/pail/data/requirements.txt
@@ -5,5 +5,8 @@ presidio-analyzer>=2.2.355
 presidio-anonymizer>=2.2.355
 flair>=0.14.0
 pandas>=2.2.2
-pyarrow
+
+# we can probably update to 18+, but we will have to re-generate expected output as pyarrow 18 seems to have resulted in a binary format change
+pyarrow<18
+
 spacy

--- a/tests/tests/python-language-text-encoder/pail/data/requirements.txt
+++ b/tests/tests/python-language-text-encoder/pail/data/requirements.txt
@@ -1,3 +1,5 @@
 sentence-transformers==3.0.1
 
-pyarrow
+# we can probably update to 18+, but we will have to re-generate expected output as pyarrow 18 seems to have resulted in a binary format change
+pyarrow<18
+

--- a/tests/tests/python-universal-doc-id/pail/data/requirements.txt
+++ b/tests/tests/python-universal-doc-id/pail/data/requirements.txt
@@ -1,4 +1,6 @@
 data-prep-toolkit==0.2.2.dev0
 
-pyarrow
+# we can probably update to 18+, but we will have to re-generate expected output as pyarrow 18 seems to have resulted in a binary format change
+pyarrow<18
+
 setuptools

--- a/tests/tests/python-universal-ededup/pail/data/requirements.txt
+++ b/tests/tests/python-universal-ededup/pail/data/requirements.txt
@@ -2,5 +2,7 @@ data-prep-toolkit==0.2.2.dev0
 mmh3==4.1.0
 xxhash==3.4.1
 
-pyarrow
+# we can probably update to 18+, but we will have to re-generate expected output as pyarrow 18 seems to have resulted in a binary format change
+pyarrow<18
+
 setuptools

--- a/tests/tests/python-universal-filter/pail/data/requirements.txt
+++ b/tests/tests/python-universal-filter/pail/data/requirements.txt
@@ -1,3 +1,5 @@
 duckdb==0.10.1
 
-pyarrow
+# we can probably update to 18+, but we will have to re-generate expected output as pyarrow 18 seems to have resulted in a binary format change
+pyarrow<18
+

--- a/tests/tests/python-universal-resize/pail/data/requirements.txt
+++ b/tests/tests/python-universal-resize/pail/data/requirements.txt
@@ -1,1 +1,3 @@
-pyarrow
+# we can probably update to 18+, but we will have to re-generate expected output as pyarrow 18 seems to have resulted in a binary format change
+pyarrow<18
+

--- a/tests/tests/python-universal-tokenization/pail/data/requirements.txt
+++ b/tests/tests/python-universal-tokenization/pail/data/requirements.txt
@@ -1,3 +1,5 @@
 transformers==4.38.2
 
-pyarrow
+# we can probably update to 18+, but we will have to re-generate expected output as pyarrow 18 seems to have resulted in a binary format change
+pyarrow<18
+


### PR DESCRIPTION
we can probably update to 18+, but we will have to re-generate expected output as pyarrow 18 seems to have resulted in a binary format change

Note: some of the python tests have transitive constraints on pyarrow <17... hence the <18 constraint we use