### PR TITLE
fix: tweak queue stats console ui

### DIFF
--- a/pkg/be/local/streamer.go
+++ b/pkg/be/local/streamer.go
@@ -97,13 +97,13 @@ func (s localStreamer) QueueStats(c chan qstat.Model, opts qstat.Options) error 
 	lines := make(chan string)
 	errs, _ := errgroup.WithContext(s.Context)
 	errs.Go(func() error {
+		defer close(lines)
 		for line := range tail.Lines {
 			if line.Err != nil {
 				return line.Err
 			}
 			lines <- line.Text
 		}
-		close(lines)
 		return nil
 	})
 


### PR DESCRIPTION
## Previously

full width, purple

![Screenshot 2024-10-28 at 12 40 43 PM](https://github.com/user-attachments/assets/ce21e9c7-1f92-454a-a1ba-ab3420db21d9)

> the weird color for the unassigned row is due to a breaking change in lipgloss/table (see below) and is a regression from #472 which bumped our dependencies

## This update

no header, natural width, gray table borders, devote colors to distinguish states (queued, in-progress, ...), combine all of the global numbers into a single row called "inbox", show pool name in a column, pretty-print worker name to remove run name and pool name.

this also updates to breaking changes in lipgloss/table. Apparently now passed to the StyleFunc, the header row has row index -1 (previously 0).

![Screenshot 2024-10-28 at 12 33 04 PM](https://github.com/user-attachments/assets/79baaaa7-0694-4b67-bca3-4b1e875c9a57)
