### PR TITLE
fix: improve error handling for needs and don't re-create venv

### DIFF
--- a/pkg/fe/transformer/api/shell/lower.go
+++ b/pkg/fe/transformer/api/shell/lower.go
@@ -52,7 +52,9 @@ func LowerAsComponent(buildName string, ctx llir.Context, app hlir.Application, 
 			}
 		}
 
-		component.Spec.Command = fmt.Sprintf(`PATH=$($LUNCHPAIL_EXE needs %s %s %s --verbose=%v):$PATH %s`, needs.Name, needs.Version, req, opts.Log.Verbose, component.Spec.Command)
+		component.Spec.Command = fmt.Sprintf(`set -e
+PATH=$($LUNCHPAIL_EXE needs %s %s %s --verbose=%v):$PATH
+%s`, needs.Name, needs.Version, req, opts.Log.Verbose, component.Spec.Command)
 	}
 
 	for _, dataset := range app.Spec.Datasets {

--- a/pkg/runtime/needs/install_requirements.go
+++ b/pkg/runtime/needs/install_requirements.go
@@ -42,6 +42,16 @@ func requirementsInstall(ctx context.Context, requirements string, verbose bool)
 		return "", err
 	}
 
+	// PATH to our venv/bin
+	path := filepath.Join(venvPath, "bin")
+
+	if _, err := os.Stat(path); err == nil {
+		// then the venv already exists
+		return path, nil
+	}
+
+	// otherwise populate the venv
+
 	//Create a requirements file in cache venv dir
 	if reqmtsFile, err = os.Create(filepath.Join(venvPath, "requirements.txt")); err != nil {
 		return "", err
@@ -61,7 +71,7 @@ pip3 install -r %s %s 1>&2`, venvPath, venvPath, verboseFlag, reqmtsFile.Name(),
 		cmd.Stdout = os.Stderr
 	}
 	cmd.Stderr = os.Stderr
-	return filepath.Join(venvPath, "bin"), cmd.Run()
+	return path, cmd.Run()
 }
 
 func getSHA256Sum(requirements []byte) (string, error) {


### PR DESCRIPTION
- We were not failing fast if needs failed #474

- We were re-issuing `python -m venv` even if the cached venv already existed. This, combined with the poor error failing of  #474 resulted in a bunch of odd failures.

Fixes #474 
