### PR TITLE
refactor: update workstealer code to separate workstealer-specific logic from queue model fetching

### DIFF
--- a/pkg/observe/queuestreamer/model.go
+++ b/pkg/observe/queuestreamer/model.go
@@ -1,23 +1,23 @@
-package workstealer
+package queuestreamer
 
 import "slices"
 
 // A Task that was assigned to a given Worker
 type AssignedTask struct {
-	pool   string
-	worker string
-	task   string
+	Pool   string
+	Worker string
+	Task   string
 }
 
 type Worker struct {
-	alive           bool
-	nSuccess        uint
-	nFail           uint
-	pool            string
-	name            string
-	assignedTasks   []string
-	processingTasks []string
-	killfilePresent bool
+	Alive           bool
+	NSuccess        uint
+	NFail           uint
+	Pool            string
+	Name            string
+	AssignedTasks   []string
+	ProcessingTasks []string
+	KillfilePresent bool
 }
 
 type TaskCode string
@@ -77,16 +77,16 @@ func (model Model) nTasksRemaining() int {
 }
 
 // Have we consumed all work that is ever going to be produced?
-func (model Model) isAllWorkDone() bool {
+func (model Model) IsAllWorkDone() bool {
 	return model.DispatcherDone && model.nFinishedTasks() > 0 && model.nTasksRemaining() == 0
 }
 
 // No live workers, some dead workers, and all dead workers have kill
 // file (meaning that we intentionally asked them to self-destruct).
-func (model Model) areAllWorkersQuiesced() bool {
+func (model Model) AreAllWorkersQuiesced() bool {
 	return len(model.LiveWorkers) == 0 &&
 		len(model.DeadWorkers) > 0 &&
-		slices.IndexFunc(model.DeadWorkers, func(w Worker) bool { return !w.killfilePresent }) < 0
+		slices.IndexFunc(model.DeadWorkers, func(w Worker) bool { return !w.KillfilePresent }) < 0
 }
 
 // Has some output been produced?
@@ -94,11 +94,6 @@ func (model Model) hasSomeOutputBeenProduced() bool {
 	return len(model.SuccessfulTasks)+len(model.FailedTasks) > 0
 }
 
-func (model Model) isAllOutputConsumed() bool {
+func (model Model) IsAllOutputConsumed() bool {
 	return model.hasSomeOutputBeenProduced() && model.nFinishedTasks() == model.nConsumedTasks()
-}
-
-// Is everything well and done: dispatcher, workers, us?
-func (model Model) readyToBye() bool {
-	return model.isAllWorkDone() && model.areAllWorkersQuiesced() && model.isAllOutputConsumed()
 }

--- a/pkg/observe/queuestreamer/patterns.go
+++ b/pkg/observe/queuestreamer/patterns.go
@@ -1,4 +1,4 @@
-package workstealer
+package queuestreamer
 
 import (
 	"regexp"
@@ -6,7 +6,7 @@ import (
 	q "lunchpail.io/pkg/ir/queue"
 )
 
-type pathPatterns struct {
+type PathPatterns struct {
 	liveWorker     *regexp.Regexp
 	deadWorker     *regexp.Regexp
 	killfile       *regexp.Regexp
@@ -19,8 +19,8 @@ type pathPatterns struct {
 	dispatcherDone *regexp.Regexp
 }
 
-func newPathPatterns(run q.RunContext) pathPatterns {
-	return pathPatterns{
+func NewPathPatterns(run q.RunContext) PathPatterns {
+	return PathPatterns{
 		liveWorker:     run.PatternFor(q.WorkerAliveMarker),
 		deadWorker:     run.PatternFor(q.WorkerDeadMarker),
 		killfile:       run.PatternFor(q.WorkerKillFile),

--- a/pkg/observe/queuestreamer/stream.go
+++ b/pkg/observe/queuestreamer/stream.go
@@ -1,0 +1,95 @@
+package queuestreamer
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"lunchpail.io/pkg/build"
+	"lunchpail.io/pkg/ir/queue"
+	s3 "lunchpail.io/pkg/runtime/queue"
+)
+
+type client struct {
+	s3 s3.S3Client
+	queue.RunContext
+	pathPatterns PathPatterns
+	build.LogOptions
+}
+
+type StreamOptions struct {
+	build.LogOptions
+
+	// If we need to resort to polling of S3, this is the polling interval we will use
+	PollingInterval int
+}
+
+func StreamModel(ctx context.Context, s3 s3.S3Client, run queue.RunContext, modelChan chan Model, doneChan chan struct{}, opts StreamOptions) error {
+	c := client{s3, run, NewPathPatterns(run), opts.LogOptions}
+
+	if err := c.s3.Mkdirp(c.RunContext.Bucket); err != nil {
+		return err
+	}
+
+	for {
+		err := once(ctx, c, modelChan, doneChan, opts)
+		if err == nil || isFatal(err) {
+			return err
+		} else {
+			// wait for s3 to be ready
+			time.Sleep(1 * time.Second)
+		}
+	}
+}
+
+func isFatal(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "unexpected EOF")
+}
+
+func once(ctx context.Context, c client, modelChan chan Model, doneChan chan struct{}, opts StreamOptions) error {
+	if opts.Verbose {
+		fmt.Fprintf(os.Stderr, "Listen bucket=%s path=%s path2=%s\n", c.RunContext.Bucket, c.RunContext.ListenPrefix(), c.RunContext.AsFile(queue.AssignedAndFinished))
+	}
+	step0Objects, step0Errs := c.s3.Listen(c.RunContext.Bucket, c.RunContext.ListenPrefix(), "", true)
+	step1Objects, step1Errs := c.s3.Listen(c.RunContext.Bucket, c.RunContext.AsFile(queue.AssignedAndFinished), "", true)
+	defer c.s3.StopListening(c.RunContext.Bucket)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-doneChan:
+			if opts.Verbose {
+				fmt.Fprintln(os.Stderr, "Queue model streamer got done notification")
+			}
+			return nil
+		case err := <-step1Errs:
+			if isFatal(err) {
+				return err
+			}
+		case err := <-step0Errs:
+			if isFatal(err) {
+				return err
+			}
+
+			fmt.Fprintf(os.Stderr, "Got push notification error: %v\n", err)
+
+			// sleep for a bit
+			time.Sleep(time.Duration(opts.PollingInterval) * time.Second)
+
+		case obj := <-step0Objects:
+			if c.LogOptions.Verbose {
+				fmt.Fprintf(os.Stderr, "Got push notification object=%s\n", obj)
+			}
+		case obj := <-step1Objects:
+			if c.LogOptions.Verbose {
+				fmt.Fprintf(os.Stderr, "Got push notification object=%s\n", obj)
+			}
+		}
+
+		// fetch and parse model
+		modelChan <- c.fetchModel()
+	}
+}

--- a/pkg/runtime/workstealer/report.go
+++ b/pkg/runtime/workstealer/report.go
@@ -5,34 +5,36 @@ import (
 	"fmt"
 	"text/tabwriter"
 	"time"
+
+	"lunchpail.io/pkg/observe/queuestreamer"
 )
 
 // Record the current state of Model for observability
-func (model Model) report(c client) error {
+func (c client) report(m queuestreamer.Model) error {
 	now := time.Now()
 
 	var b bytes.Buffer
 	writer := tabwriter.NewWriter(&b, 0, 8, 1, '\t', tabwriter.AlignRight)
 
-	fmt.Fprintf(writer, "lunchpail.io\tunassigned\t%d\t\t\t\t\t%s\t%s\n", len(model.UnassignedTasks), c.RunContext.RunName, now.Format(time.UnixDate))
-	fmt.Fprintf(writer, "lunchpail.io\tdispatcherDone\t%v\t\t\t\t\t%s\n", model.DispatcherDone, c.RunContext.RunName)
-	fmt.Fprintf(writer, "lunchpail.io\tassigned\t%d\t\t\t\t\t%s\n", len(model.AssignedTasks), c.RunContext.RunName)
-	fmt.Fprintf(writer, "lunchpail.io\tprocessing\t\t%d\t\t\t\t%s\n", len(model.ProcessingTasks), c.RunContext.RunName)
-	fmt.Fprintf(writer, "lunchpail.io\toutbox\t\t\t%d\t\t\t%s\n", len(model.OutboxTasks), c.RunContext.RunName)
-	fmt.Fprintf(writer, "lunchpail.io\tdone\t\t\t%d\t%d\t\t%s\n", len(model.SuccessfulTasks), len(model.FailedTasks), c.RunContext.RunName)
-	fmt.Fprintf(writer, "lunchpail.io\tliveworkers\t%d\t\t\t\t\t%s\n", len(model.LiveWorkers), c.RunContext.RunName)
-	fmt.Fprintf(writer, "lunchpail.io\tdeadworkers\t%d\t\t\t\t\t%s\n", len(model.DeadWorkers), c.RunContext.RunName)
+	fmt.Fprintf(writer, "lunchpail.io\tunassigned\t%d\t\t\t\t\t%s\t%s\n", len(m.UnassignedTasks), c.RunContext.RunName, now.Format(time.UnixDate))
+	fmt.Fprintf(writer, "lunchpail.io\tdispatcherDone\t%v\t\t\t\t\t%s\n", m.DispatcherDone, c.RunContext.RunName)
+	fmt.Fprintf(writer, "lunchpail.io\tassigned\t%d\t\t\t\t\t%s\n", len(m.AssignedTasks), c.RunContext.RunName)
+	fmt.Fprintf(writer, "lunchpail.io\tprocessing\t\t%d\t\t\t\t%s\n", len(m.ProcessingTasks), c.RunContext.RunName)
+	fmt.Fprintf(writer, "lunchpail.io\toutbox\t\t\t%d\t\t\t%s\n", len(m.OutboxTasks), c.RunContext.RunName)
+	fmt.Fprintf(writer, "lunchpail.io\tdone\t\t\t%d\t%d\t\t%s\n", len(m.SuccessfulTasks), len(m.FailedTasks), c.RunContext.RunName)
+	fmt.Fprintf(writer, "lunchpail.io\tliveworkers\t%d\t\t\t\t\t%s\n", len(m.LiveWorkers), c.RunContext.RunName)
+	fmt.Fprintf(writer, "lunchpail.io\tdeadworkers\t%d\t\t\t\t\t%s\n", len(m.DeadWorkers), c.RunContext.RunName)
 
-	for _, worker := range model.LiveWorkers {
+	for _, worker := range m.LiveWorkers {
 		fmt.Fprintf(
 			writer, "lunchpail.io\tliveworker\t%d\t%d\t%d\t%d\t%s/%s\t%s\t%v\n",
-			len(worker.assignedTasks), len(worker.processingTasks), worker.nSuccess, worker.nFail, worker.pool, worker.name, c.RunContext.RunName, worker.killfilePresent,
+			len(worker.AssignedTasks), len(worker.ProcessingTasks), worker.NSuccess, worker.NFail, worker.Pool, worker.Name, c.RunContext.RunName, worker.KillfilePresent,
 		)
 	}
-	for _, worker := range model.DeadWorkers {
+	for _, worker := range m.DeadWorkers {
 		fmt.Fprintf(
 			writer, "lunchpail.io\tdeadworker\t%d\t%d\t%d\t%d\t%s/%s\t%s\n",
-			len(worker.assignedTasks), len(worker.processingTasks), worker.nSuccess, worker.nFail, worker.pool, worker.name, c.RunContext.RunName,
+			len(worker.AssignedTasks), len(worker.ProcessingTasks), worker.NSuccess, worker.NFail, worker.Pool, worker.Name, c.RunContext.RunName,
 		)
 	}
 	fmt.Fprintln(writer, "lunchpail.io\t---")


### PR DESCRIPTION
This should enable us to reuse the queue model fetching for the `queue stats` command (which currently uses a separate path for fetching and parsing a model, and even that model is separate from the one used by the workstealer)

new `pkg/observe/queuestreamer.StreamModel()`