### PR TITLE
feat: update `queue stat` to use new pkg/observe/queuestreamer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.23.2
 
 require (
 	github.com/IBM/go-sdk-core/v5 v5.18.1
+	github.com/bep/debounce v1.2.1
 	github.com/charmbracelet/lipgloss v0.13.1
 	github.com/dustin/go-humanize v1.0.1
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bep/debounce v1.2.1 h1:v67fRdBA9UQu2NhLFXrSg0Brw7CexQekrBwDMM8bzeY=
+github.com/bep/debounce v1.2.1/go.mod h1:H8yggRPQKLUhUoqrJC1bO2xNya7vanpDl7xR3ISbCJ0=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bshuster-repo/logrus-logstash-hook v1.0.0 h1:e+C0SB5R1pu//O4MQ3f9cFuPGoOVeF2fE4Og9otCc70=

--- a/pkg/runtime/queue/client.go
+++ b/pkg/runtime/queue/client.go
@@ -22,6 +22,7 @@ type S3Client struct {
 
 type S3ClientStop struct {
 	S3Client
+	queue.RunContext
 	Stop func()
 }
 
@@ -92,5 +93,5 @@ func NewS3ClientForRun(ctx context.Context, backend be.Backend, runname string) 
 		c.Paths = paths
 	}
 
-	return S3ClientStop{c, stop}, nil
+	return S3ClientStop{c, queue.RunContext{RunName: runname, Bucket: c.Paths.Bucket}, stop}, nil
 }


### PR DESCRIPTION
This is in place of the separate path of pkg/be/streamer.QueueStats() which fed off the stdout "reports" from the workstealer. With this change, `queue stat` feeds directly off push notifications from minio (if supported).

This also introduces the use of a debouncer in qstat.UI to avoid flurries of output.