### PR TITLE
fix: queue stat has bugs when displaying multiple steps

### DIFF
--- a/pkg/observe/qstat/ui.go
+++ b/pkg/observe/qstat/ui.go
@@ -48,7 +48,7 @@ func UI(ctx context.Context, runnameIn string, backend be.Backend, opts Options)
 		debounced(func() {
 			t := r.render(model)
 			for idx, step := range model.Steps {
-				r.step(idx, idx == len(model.Steps)-1, step, t)
+				r.step(idx, step, t)
 			}
 		})
 


### PR DESCRIPTION
We had an erroneous notion of "is final step" and inbox vs outbox.