### PR TITLE
feat: use a single workstealer for entire pipeline

### DIFF
--- a/hack/pipeline-demo.sh
+++ b/hack/pipeline-demo.sh
@@ -25,4 +25,5 @@ fi
 step="$stepo up --verbose=${VERBOSE:-false}"
 
 echo "Launching pipeline"
-$step <(echo 1) <(echo 2) <(echo 3) <(echo 4) <(echo 5) <(echo 6) <(echo 7) <(echo 8) <(echo 9) <(echo 10) | $step | $step | $step | $step | $step | $step | $step
+$step <(echo 1) <(echo 2) <(echo 3) <(echo 4) <(echo 5) <(echo 6) <(echo 7) <(echo 8) <(echo 9) <(echo 10) \
+    | $step | $step | $step | $step | $step | $step | $step

--- a/pkg/be/local/shell/spawn.go
+++ b/pkg/be/local/shell/spawn.go
@@ -27,6 +27,7 @@ func Spawn(ctx context.Context, c llir.ShellComponent, ir llir.LLIR, logdir stri
 	if err != nil {
 		return err
 	}
+	defer os.RemoveAll(workdir)
 
 	// tee command output to the logdir
 	instance := strings.Replace(strings.Replace(c.InstanceName, ir.RunName(), "", 1), "--", "-", 1)

--- a/pkg/be/local/shell/workdir.go
+++ b/pkg/be/local/shell/workdir.go
@@ -1,9 +1,8 @@
 package shell
 
 import (
-	base64 "encoding/base64"
+	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -13,7 +12,15 @@ import (
 )
 
 func PrepareWorkdirForComponent(c llir.ShellComponent, opts build.LogOptions) (string, string, error) {
-	workdir, err := ioutil.TempDir("", "lunchpail")
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", "", err
+	}
+	tmp := filepath.Join(home, ".lunchpail", "tmp")
+	if err := os.MkdirAll(tmp, os.ModePerm); err != nil {
+		return "", "", err
+	}
+	workdir, err := os.MkdirTemp(tmp, string(c.C()))
 	if err != nil {
 		return "", "", err
 	}

--- a/pkg/fe/transformer/api/workstealer/transpile.go
+++ b/pkg/fe/transformer/api/workstealer/transpile.go
@@ -16,10 +16,9 @@ func transpile(ctx llir.Context, opts build.LogOptions) (hlir.Application, error
 
 	app.Spec.Image = fmt.Sprintf("%s/%s/lunchpail:%s", lunchpail.ImageRegistry, lunchpail.ImageRepo, lunchpail.Version())
 	app.Spec.Role = "workstealer"
-	app.Spec.Command = fmt.Sprintf("$LUNCHPAIL_EXE component workstealer run --verbose=%v --debug=%v --self-destruct=%v",
+	app.Spec.Command = fmt.Sprintf("$LUNCHPAIL_EXE component workstealer run --verbose=%v --debug=%v --self-destruct=true",
 		opts.Verbose,
 		opts.Debug,
-		ctx.Run.IsFinalStep,
 	)
 
 	app.Spec.Env = hlir.Env{}

--- a/pkg/fe/transformer/application.go
+++ b/pkg/fe/transformer/application.go
@@ -12,7 +12,7 @@ import (
 func lowerApplications(buildName string, ctx llir.Context, model hlir.HLIR, opts build.Options) ([]llir.Component, error) {
 	components := []llir.Component{}
 
-	if workstealer.IsNeeded(model) {
+	if ctx.Run.Step == 0 && workstealer.IsNeeded(model) {
 		// Note, the actual worker resources will be dealt
 		// with when a WorkerPool is created. Here, we only
 		// need to specify a WorkStealer.

--- a/pkg/observe/queuestreamer/fetch.go
+++ b/pkg/observe/queuestreamer/fetch.go
@@ -114,7 +114,7 @@ func (model *Model) update(filepath string, patterns PathPatterns) {
 		copy(steps, model.Steps)
 		i := len(model.Steps)
 		for i <= step {
-			steps = append(steps, Step{})
+			steps = append(steps, Step{Index: step})
 			i++
 		}
 		model.Steps = steps

--- a/pkg/observe/queuestreamer/model.go
+++ b/pkg/observe/queuestreamer/model.go
@@ -20,13 +20,6 @@ type Worker struct {
 	KillfilePresent bool
 }
 
-type TaskCode string
-
-const (
-	succeeded TaskCode = "succeeded"
-	failed    TaskCode = "failed"
-)
-
 // The current state of the world
 type Model struct {
 	// One sub-model per step
@@ -34,6 +27,9 @@ type Model struct {
 }
 
 type Step struct {
+	// Step index
+	Index int
+
 	// has dispatcher dropped its donefile, indicating no more
 	// work is forthcoming?
 	DispatcherDone bool

--- a/pkg/runtime/builtins/redirect.go
+++ b/pkg/runtime/builtins/redirect.go
@@ -29,7 +29,7 @@ func RedirectTo(ctx context.Context, client s3.S3Client, run queue.RunContext, f
 		dst := filepath.Join(dstFolder, strings.Replace(withoutExt, outbox+"/", "", 1)+".output"+ext)
 		group.Go(func() error {
 			if opts.Verbose {
-				fmt.Fprintf(os.Stderr, "Downloading output to %s\n", dst)
+				fmt.Fprintf(os.Stderr, "Downloading output %s to %s\n", object, dst)
 			}
 			if err := client.Download(client.Paths.Bucket, object, dst); err != nil {
 				if opts.Verbose {

--- a/pkg/runtime/workstealer/report.go
+++ b/pkg/runtime/workstealer/report.go
@@ -16,7 +16,7 @@ func (c client) report(m queuestreamer.Step) error {
 	var b bytes.Buffer
 	writer := tabwriter.NewWriter(&b, 0, 8, 1, '\t', tabwriter.AlignRight)
 
-	fmt.Fprintf(writer, "lunchpail.io\tunassigned\t%d\t\t\t\t\t%s\t%s\n", len(m.UnassignedTasks), c.RunContext.RunName, now.Format(time.UnixDate))
+	fmt.Fprintf(writer, "lunchpail.io\tunassigned\t%d\t\t\t\t\t%s\t%s\tstep=%d\n", len(m.UnassignedTasks), c.RunContext.RunName, now.Format(time.UnixDate), m.Index)
 	fmt.Fprintf(writer, "lunchpail.io\tdispatcherDone\t%v\t\t\t\t\t%s\n", m.DispatcherDone, c.RunContext.RunName)
 	fmt.Fprintf(writer, "lunchpail.io\tassigned\t%d\t\t\t\t\t%s\n", len(m.AssignedTasks), c.RunContext.RunName)
 	fmt.Fprintf(writer, "lunchpail.io\tprocessing\t\t%d\t\t\t\t%s\n", len(m.ProcessingTasks), c.RunContext.RunName)

--- a/tests/bin/helpers.sh
+++ b/tests/bin/helpers.sh
@@ -146,7 +146,7 @@ function waitForEveryoneToDie {
 
     if [[ "$NUM_DESIRED_OUTPUTS:-1" != "0" ]]
     then
-        # workstealer should not auto-self-destruct
+        # workstealer should not auto-self-destruct since we have not drained the output
         waitForNInstances 1 $run_name workstealer
 
         # drain the output

--- a/tests/bin/run.sh
+++ b/tests/bin/run.sh
@@ -108,7 +108,7 @@ then
         fi
     else
         "$SCRIPTDIR"/up.sh $testname &
-        # "$testapp" logs -c workstealer -t $LUNCHPAIL_TARGET -f &
+        "$testapp" logs -c workstealer -t $LUNCHPAIL_TARGET -f &
     fi
 
     if [[ -e "$1"/init.sh ]]; then


### PR DESCRIPTION
This reduces overhead, but mainly helps to fix a lingering problem: the `readyToBye` logic as implemented with one workstealer per step resulted in later steps potentially exiting as they would think no more work remained (depending on race windows...). With a single workstealer, it can keep track of this status across the entire pipeline.

Also:
- add more steps to pipeline-demo.sh
- update queue stat UI so that it updates in place, rather than scrolling a new table for every update
- update workstealer to debounce the queuestreamer.Model channel -- no point in having the workstealer respond to every single update to the queue, as long as it eventually responds
- avoids 'unexpected EOF' errors from `queue stat`