### PR TITLE
fix: needs minio on linux downloads minio multiple times

### DIFF
--- a/pkg/runtime/needs/install_darwin.go
+++ b/pkg/runtime/needs/install_darwin.go
@@ -17,6 +17,11 @@ func homedir() (string, error) {
 	return currentUser.HomeDir, nil
 }
 
+// We use `brew` and so don't require a special PATH
+func bindir() (string, error) {
+	return "", nil
+}
+
 func installMinio(ctx context.Context, version string, verbose bool) (string, error) {
 	if err := setenv(); err != nil { //$HOME must be set for brew
 		return "", err

--- a/pkg/runtime/needs/minio.go
+++ b/pkg/runtime/needs/minio.go
@@ -3,15 +3,37 @@ package needs
 import (
 	"context"
 	"errors"
+	"fmt"
+	"os"
 	"os/exec"
 )
 
 func InstallMinio(ctx context.Context, version string, opts Options) (string, error) {
+	// We may have installed minio in a special place. Before we
+	// can call LookPath, make sure that special place is on PATH.
+	dir, err := bindir()
+	if err != nil {
+		return "", err
+	}
+
+	if dir != "" {
+		if opts.Verbose {
+			fmt.Fprintf(os.Stderr, "needs minio adding dir to PATH=%s\n", dir)
+		}
+		os.Setenv("PATH", os.Getenv("PATH")+":"+dir)
+	}
+
 	if _, err := exec.LookPath("minio"); err != nil {
 		if errors.Is(err, exec.ErrNotFound) {
+			if opts.Verbose {
+				fmt.Fprintln(os.Stderr, "needs minio installing minio")
+			}
 			return installMinio(ctx, version, opts.Verbose)
 		}
 		return "", err
 	}
-	return "", nil
+	if opts.Verbose {
+		fmt.Fprintln(os.Stderr, "needs minio found minio")
+	}
+	return dir, nil
 }


### PR DESCRIPTION
We call `os.LookPath("minio")` but on Linux, we install minio in a special place that may not be on PATH when we call LookPath.