### PR TITLE
fix: move stdout/stderr/code files out of main queue paths

### DIFF
--- a/pkg/ir/queue/listen.go
+++ b/pkg/ir/queue/listen.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-// i.e. "/run/{{.RunName}}/step/{{.Step}}"
+// i.e. "/run/{{.RunName}}/queue/step/{{.Step}}"
 func (run RunContext) ListenPrefix() string {
 	return run.ListenPrefixForAnyStep(false)
 }

--- a/pkg/ir/queue/paths.go
+++ b/pkg/ir/queue/paths.go
@@ -3,18 +3,18 @@ package queue
 type Path string
 
 const (
-	Unassigned            Path = "lunchpail/run/{{.RunName}}/step/{{.Step}}/unassigned/{{.Task}}"
-	AssignedAndPending         = "lunchpail/run/{{.RunName}}/step/{{.Step}}/inbox/pool/{{.PoolName}}/worker/{{.WorkerName}}/{{.Task}}"
-	AssignedAndProcessing      = "lunchpail/run/{{.RunName}}/step/{{.Step}}/processing/pool/{{.PoolName}}/worker/{{.WorkerName}}/{{.Task}}"
-	AssignedAndFinished        = `lunchpail/run/{{.RunName}}/step/{{len (printf "a%*s" .Step "")}}/unassigned/{{.Task}}` // i.e. step 1's output is step 2's input; the len is magic for +1 https://stackoverflow.com/a/72465098/5270773
-	FinishedWithCode           = "lunchpail/run/{{.RunName}}/step/{{.Step}}/exitcode/pool/{{.PoolName}}/worker/{{.WorkerName}}/{{.Task}}"
-	FinishedWithStdout         = "lunchpail/run/{{.RunName}}/step/{{.Step}}/stdout/pool/{{.PoolName}}/worker/{{.WorkerName}}/{{.Task}}"
-	FinishedWithStderr         = "lunchpail/run/{{.RunName}}/step/{{.Step}}/stderr/pool/{{.PoolName}}/worker/{{.WorkerName}}/{{.Task}}"
-	FinishedWithSucceeded      = "lunchpail/run/{{.RunName}}/step/{{.Step}}/succeeded/pool/{{.PoolName}}/worker/{{.WorkerName}}/{{.Task}}"
-	FinishedWithFailed         = "lunchpail/run/{{.RunName}}/step/{{.Step}}/failed/pool/{{.PoolName}}/worker/{{.WorkerName}}/{{.Task}}"
-	WorkerKillFile             = "lunchpail/run/{{.RunName}}/step/{{.Step}}/killfiles/pool/{{.PoolName}}/worker/{{.WorkerName}}"
-	AllDoneMarker              = "lunchpail/run/{{.RunName}}/alldone" // Note: not step-specific!
-	DispatcherDoneMarker       = "lunchpail/run/{{.RunName}}/step/{{.Step}}/marker/dispatcherdone"
-	WorkerAliveMarker          = "lunchpail/run/{{.RunName}}/step/{{.Step}}/marker/alive/pool/{{.PoolName}}/worker/{{.WorkerName}}"
-	WorkerDeadMarker           = "lunchpail/run/{{.RunName}}/step/{{.Step}}/marker/dead/pool/{{.PoolName}}/worker/{{.WorkerName}}"
+	Unassigned            Path = "lunchpail/run/{{.RunName}}/queue/step/{{.Step}}/unassigned/{{.Task}}"
+	AssignedAndPending         = "lunchpail/run/{{.RunName}}/queue/step/{{.Step}}/inbox/pool/{{.PoolName}}/worker/{{.WorkerName}}/{{.Task}}"
+	AssignedAndProcessing      = "lunchpail/run/{{.RunName}}/queue/step/{{.Step}}/processing/pool/{{.PoolName}}/worker/{{.WorkerName}}/{{.Task}}"
+	AssignedAndFinished        = `lunchpail/run/{{.RunName}}/queue/step/{{len (printf "a%*s" .Step "")}}/unassigned/{{.Task}}` // i.e. step 1's output is step 2's input; the len is magic for +1 https://stackoverflow.com/a/72465098/5270773
+	FinishedWithCode           = "lunchpail/run/{{.RunName}}/meta/step/{{.Step}}/exitcode/pool/{{.PoolName}}/worker/{{.WorkerName}}/{{.Task}}"
+	FinishedWithStdout         = "lunchpail/run/{{.RunName}}/meta/step/{{.Step}}/stdout/pool/{{.PoolName}}/worker/{{.WorkerName}}/{{.Task}}"
+	FinishedWithStderr         = "lunchpail/run/{{.RunName}}/meta/step/{{.Step}}/stderr/pool/{{.PoolName}}/worker/{{.WorkerName}}/{{.Task}}"
+	FinishedWithSucceeded      = "lunchpail/run/{{.RunName}}/queue/step/{{.Step}}/succeeded/pool/{{.PoolName}}/worker/{{.WorkerName}}/{{.Task}}"
+	FinishedWithFailed         = "lunchpail/run/{{.RunName}}/queue/step/{{.Step}}/failed/pool/{{.PoolName}}/worker/{{.WorkerName}}/{{.Task}}"
+	WorkerKillFile             = "lunchpail/run/{{.RunName}}/queue/step/{{.Step}}/killfiles/pool/{{.PoolName}}/worker/{{.WorkerName}}"
+	AllDoneMarker              = "lunchpail/run/{{.RunName}}/queue/alldone" // Note: not step-specific!
+	DispatcherDoneMarker       = "lunchpail/run/{{.RunName}}/queue/step/{{.Step}}/marker/dispatcherdone"
+	WorkerAliveMarker          = "lunchpail/run/{{.RunName}}/queue/step/{{.Step}}/marker/alive/pool/{{.PoolName}}/worker/{{.WorkerName}}"
+	WorkerDeadMarker           = "lunchpail/run/{{.RunName}}/queue/step/{{.Step}}/marker/dead/pool/{{.PoolName}}/worker/{{.WorkerName}}"
 )

--- a/tests/bin/helpers.sh
+++ b/tests/bin/helpers.sh
@@ -114,17 +114,17 @@ function waitForIt {
                 if [ -n "$expectTaskFailure" ]
                 then ofile="failed"
                 fi
-                while ! $testapp queue ls --target ${LUNCHPAIL_TARGET:-kubernetes} $ofile | grep -Fq "${output}"
-                do echo "Still waiting for $ofile test=$name output=$output" && sleep 1
+                while ! $testapp queue ls --target ${LUNCHPAIL_TARGET:-kubernetes} $ofile | grep -Fq "$(basename $output)"
+                do echo "Still waiting for $ofile test=$name output=$(basename $output)" && sleep 1
                 done
-                echo "✅ PASS got expected $ofile file test=$name output=$output"
+                echo "✅ PASS got expected $ofile file test=$name output=$(basename $output)"
 
-                while ! $testapp queue ls --target ${LUNCHPAIL_TARGET:-kubernetes} stdout | grep -Fq "${output}"
+                while ! $testapp queue ls --target ${LUNCHPAIL_TARGET:-kubernetes} stdout | grep -Fq "$(basename $output)"
                 do echo "Still waiting for stdout test=$name output=$output" && sleep 1
                 done
                 echo "✅ PASS got stdout file test=$name output=$output"
 
-                while ! $testapp queue ls --target ${LUNCHPAIL_TARGET:-kubernetes} stderr | grep -Fq "${output}"
+                while ! $testapp queue ls --target ${LUNCHPAIL_TARGET:-kubernetes} stderr | grep -Fq "$(basename $output)"
                 do echo "Still waiting for stderr test=$name output=$output" && sleep 1
                 done
                 echo "✅ PASS got stderr file test=$name output=$output"


### PR DESCRIPTION
The workstealer and queue stat don't need to receive updates for stdout/stderr/code files.