### PR TITLE
fix: improve log and portforward output for be/kubernetes

### DIFF
--- a/cmd/subcommands/queue/cat.go
+++ b/cmd/subcommands/queue/cat.go
@@ -41,7 +41,7 @@ func Cat() *cobra.Command {
 			return err
 		}
 
-		return queue.Qcat(ctx, backend, run, args[0])
+		return queue.Qcat(ctx, backend, run, args[0], *opts.Log)
 	}
 
 	return cmd

--- a/cmd/subcommands/queue/drain.go
+++ b/cmd/subcommands/queue/drain.go
@@ -40,7 +40,7 @@ func Drain() *cobra.Command {
 			return err
 		}
 
-		return queue.Drain(ctx, backend, run)
+		return queue.Drain(ctx, backend, run, *opts.Log)
 	}
 
 	return cmd

--- a/cmd/subcommands/queue/ls.go
+++ b/cmd/subcommands/queue/ls.go
@@ -57,7 +57,7 @@ func Ls() *cobra.Command {
 			return err
 		}
 
-		files, errors, err := queue.Ls(ctx, backend, runContext, path)
+		files, errors, err := queue.Ls(ctx, backend, runContext, path, *opts.Log)
 		if err != nil {
 			return err
 		}

--- a/cmd/subcommands/queue/upload.go
+++ b/cmd/subcommands/queue/upload.go
@@ -38,7 +38,7 @@ func Upload() *cobra.Command {
 		}
 
 		run := q.RunContext{RunName: runOpts.Run}
-		return queue.UploadFiles(ctx, backend, run, []upload.Upload{upload.Upload{Path: args[0], Bucket: args[1]}})
+		return queue.UploadFiles(ctx, backend, run, []upload.Upload{upload.Upload{Path: args[0], Bucket: args[1]}}, *opts.Log)
 	}
 
 	return cmd

--- a/hack/dpk.sh
+++ b/hack/dpk.sh
@@ -7,7 +7,10 @@ fi
 mkdir -p dpk
 
 for i in tests/tests/python*
-do ./lunchpail build -o dpk/$(basename "$i") "$i"/pail --target local --create-namespace &
+do
+    if [[ -z "$1" ]] || [[ "$1" = $(basename "$i") ]]
+    then ./lunchpail build -o dpk/$(basename "$i") "$i"/pail --target local --create-namespace &
+    fi
 done
 
 wait

--- a/pkg/be/backend.go
+++ b/pkg/be/backend.go
@@ -5,6 +5,7 @@ import (
 
 	"lunchpail.io/pkg/be/runs"
 	"lunchpail.io/pkg/be/streamer"
+	"lunchpail.io/pkg/build"
 	"lunchpail.io/pkg/ir/llir"
 	"lunchpail.io/pkg/ir/queue"
 	"lunchpail.io/pkg/lunchpail"
@@ -32,11 +33,8 @@ type Backend interface {
 	// Number of instances of the given component for the given run
 	InstanceCount(ctx context.Context, c lunchpail.Component, run queue.RunContext) (int, error)
 
-	// Queue properties for a given run
-	Queue(ctx context.Context, run queue.RunContext) (endpoint, accessKeyID, secretAccessKey, bucket string, err error)
-
 	// Queue properties for a given run, plus ensure access to the endpoint from this client
-	AccessQueue(ctx context.Context, run queue.RunContext) (endpoint, accessKeyID, secretAccessKey, bucket string, stop func(), err error)
+	AccessQueue(ctx context.Context, run queue.RunContext, opts build.LogOptions) (endpoint, accessKeyID, secretAccessKey, bucket string, stop func(), err error)
 
 	// Return a streamer
 	Streamer(ctx context.Context, run queue.RunContext) streamer.Streamer

--- a/pkg/be/ibmcloud/queue.go
+++ b/pkg/be/ibmcloud/queue.go
@@ -4,16 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"lunchpail.io/pkg/build"
 	"lunchpail.io/pkg/ir/queue"
 )
 
 // Queue properties for a given run, plus ensure access to the endpoint from this client
-func (backend Backend) AccessQueue(ctx context.Context, run queue.RunContext) (endpoint, accessKeyID, secretAccessKey, bucket string, stop func(), err error) {
+func (backend Backend) AccessQueue(ctx context.Context, run queue.RunContext, opts build.LogOptions) (endpoint, accessKeyID, secretAccessKey, bucket string, stop func(), err error) {
 	err = fmt.Errorf("Unsupported operation: 'AccessQueue'")
-	return
-}
-
-func (backend Backend) Queue(ctx context.Context, run queue.RunContext) (endpoint, accessKeyID, secretAccessKey, bucket string, err error) {
-	err = fmt.Errorf("Unsupported operation: 'Queue'")
 	return
 }

--- a/pkg/be/kubernetes/portforward.go
+++ b/pkg/be/kubernetes/portforward.go
@@ -7,23 +7,34 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
+
+	"lunchpail.io/pkg/build"
 )
 
-func retryOnError(err error) bool {
+func retryOnError(ctx context.Context, err error) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	default:
+	}
+
 	if strings.Contains(err.Error(), "connection refused") {
-		time.Sleep(3 * time.Second)
+		time.Sleep(2 * time.Second)
 		return true
 	}
 
 	return false
 }
 
-func (backend Backend) portForward(ctx context.Context, podName string, localPort, podPort int) (func(), error) {
+func (backend Backend) portForward(ctx context.Context, podName string, localPort, podPort int, opts build.LogOptions) (func(), error) {
 	c, restConfig, err := Client()
 	if err != nil {
 		return func() {}, err
@@ -39,50 +50,81 @@ func (backend Backend) portForward(ctx context.Context, podName string, localPor
 	// readyCh communicate when the port forward is ready to get traffic
 	readyCh := make(chan struct{})
 
+	// we will set this below when a successfully launched
+	// portforwarder exits normally
+	done := false
+
 	// managing termination signal from the terminal. As you can see the stopCh
 	// gets closed to gracefully handle its termination.
-	/*sigs := make(chan os.Signal, 1)
+	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
-	group.Go(func() error {
+	go func() error {
 		<-sigs
-		close(stopCh)
+		if !done {
+			if opts.Debug {
+				fmt.Fprintln(os.Stderr, "SIGINT/TERM has initiated close of portforward closed", os.Args)
+			}
+			done = true
+			close(stopCh)
+		}
 		return nil
-	})*/
+	}()
 
 	go func() error {
-		for {
+		// hmmm... the client-go portforward.go logs an UnhandledError when things are all done and good...
+		// portforward.go:413] "Unhandled Error" err="an error occurred forwarding
+		runtime.ErrorHandlers = []runtime.ErrorHandler{}
+
+		for !done {
+			select {
+			case <-ctx.Done():
+				return nil
+			default:
+			}
+
 			path := fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/portforward",
 				backend.namespace, podName)
 			hostIP := strings.TrimLeft(restConfig.Host, "htps:/")
 
 			transport, upgrader, err := spdy.RoundTripperFor(restConfig)
 			if err != nil {
-				if !retryOnError(err) {
+				if !retryOnError(ctx, err) {
 					return err
 				}
 				continue
 			}
 
-			stdout := ioutil.Discard // TODO verbose?
-			stderr := os.Stderr
+			stdout := ioutil.Discard
+			stderr := ioutil.Discard
+			if opts.Verbose {
+				stdout = os.Stderr
+				stderr = os.Stderr
+			}
 
 			dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, http.MethodPost, &url.URL{Scheme: "https", Path: path, Host: hostIP})
 
 			fw, err := portforward.New(dialer, []string{fmt.Sprintf("%d:%d", localPort, podPort)}, stopCh, readyCh, stdout, stderr)
 			if err != nil {
-				if !retryOnError(err) {
+				if !retryOnError(ctx, err) {
 					return err
 				}
 				continue
 			}
 
 			if err := fw.ForwardPorts(); err != nil {
-				if !retryOnError(err) {
+				if !retryOnError(ctx, err) {
 					return err
 				}
 				continue
 			}
+
+			if opts.Verbose {
+				fmt.Fprintln(os.Stderr, "Portforward closed", os.Args)
+			}
+			done = true
 		}
+
+		return nil
 	}()
 
 	// wait for it to be ready
@@ -90,7 +132,13 @@ func (backend Backend) portForward(ctx context.Context, podName string, localPor
 
 	stop := func() {
 		// hmm... for kubernetes backends, this can result in a panic: close on closed channel
-		// close(stopCh)
+		if !done {
+			if opts.Debug {
+				fmt.Fprintln(os.Stderr, "Client has requested close of portforward closed", os.Args)
+			}
+			done = true
+			close(stopCh)
+		}
 	}
 
 	return stop, nil

--- a/pkg/be/local/queue.go
+++ b/pkg/be/local/queue.go
@@ -8,18 +8,19 @@ import (
 	"time"
 
 	"lunchpail.io/pkg/be/local/files"
+	"lunchpail.io/pkg/build"
 	"lunchpail.io/pkg/ir/llir"
 	"lunchpail.io/pkg/ir/queue"
 )
 
 // Queue properties for a given run, plus ensure access to the endpoint from this client
-func (backend Backend) AccessQueue(ctx context.Context, run queue.RunContext) (endpoint, accessKeyID, secretAccessKey, bucket string, stop func(), err error) {
-	endpoint, accessKeyID, secretAccessKey, bucket, err = backend.Queue(ctx, run)
+func (backend Backend) AccessQueue(ctx context.Context, run queue.RunContext, opts build.LogOptions) (endpoint, accessKeyID, secretAccessKey, bucket string, stop func(), err error) {
+	endpoint, accessKeyID, secretAccessKey, bucket, err = backend.queue(ctx, run)
 	stop = func() {}
 	return
 }
 
-func (backend Backend) Queue(ctx context.Context, run queue.RunContext) (endpoint, accessKeyID, secretAccessKey, bucket string, err error) {
+func (backend Backend) queue(ctx context.Context, run queue.RunContext) (endpoint, accessKeyID, secretAccessKey, bucket string, err error) {
 	spec, rerr := restoreContext(run)
 	if rerr != nil {
 		err = rerr

--- a/pkg/boot/alldone.go
+++ b/pkg/boot/alldone.go
@@ -11,7 +11,7 @@ import (
 )
 
 func waitForAllDone(ctx context.Context, backend be.Backend, run queue.RunContext, opts build.LogOptions) error {
-	client, err := s3.NewS3ClientForRun(ctx, backend, run.RunName)
+	client, err := s3.NewS3ClientForRun(ctx, backend, run.RunName, opts)
 	if err != nil {
 		if strings.Contains(err.Error(), "Connection closed") {
 			// already gone

--- a/pkg/boot/failures.go
+++ b/pkg/boot/failures.go
@@ -13,7 +13,7 @@ import (
 )
 
 func lookForTaskFailures(ctx context.Context, backend be.Backend, run queue.RunContext, opts build.LogOptions) error {
-	client, err := s3.NewS3ClientForRun(ctx, backend, run.RunName)
+	client, err := s3.NewS3ClientForRun(ctx, backend, run.RunName, opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/boot/io.go
+++ b/pkg/boot/io.go
@@ -19,7 +19,7 @@ import (
 
 // Behave like `cat inputs | ... > outputs`
 func catAndRedirect(ctx context.Context, inputs []string, backend be.Backend, ir llir.LLIR, opts build.LogOptions) error {
-	client, err := s3.NewS3ClientForRun(ctx, backend, ir.Context.Run.RunName)
+	client, err := s3.NewS3ClientForRun(ctx, backend, ir.Context.Run.RunName, opts)
 	if err != nil {
 		return err
 	}
@@ -75,7 +75,7 @@ func catAndRedirect(ctx context.Context, inputs []string, backend be.Backend, ir
 
 // For Step > 0, we will need to simulate that a dispatch is done
 func fakeDispatch(ctx context.Context, backend be.Backend, run queue.RunContext, opts build.LogOptions) error {
-	client, err := s3.NewS3ClientForRun(ctx, backend, run.RunName)
+	client, err := s3.NewS3ClientForRun(ctx, backend, run.RunName, opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/boot/up.go
+++ b/pkg/boot/up.go
@@ -184,7 +184,7 @@ func upLLIR(ctx context.Context, backend be.Backend, ir llir.LLIR, opts UpOption
 
 	//inject executable into s3
 	if opts.Executable != "" {
-		if err := s3.UploadFiles(ctx, backend, ir.Context.Run, []upload.Upload{upload.Upload{Path: q.Executable, Bucket: ir.Context.Run.Bucket}}); err != nil {
+		if err := s3.UploadFiles(ctx, backend, ir.Context.Run, []upload.Upload{upload.Upload{Path: q.Executable, Bucket: ir.Context.Run.Bucket}}, *opts.BuildOptions.Log); err != nil {
 			fmt.Fprintln(os.Stderr, err)
 		}
 	}

--- a/pkg/observe/logs.go
+++ b/pkg/observe/logs.go
@@ -35,6 +35,10 @@ func Logs(ctx context.Context, runnameIn string, backend be.Backend, opts LogsOp
 
 	useComponentPrefix := len(opts.Components) > 1
 
+	if opts.Tail == 0 {
+		opts.Tail = -1
+	}
+
 	group, _ := errgroup.WithContext(ctx)
 	s := backend.Streamer(ctx, queue.RunContext{RunName: runname})
 	for _, component := range opts.Components {

--- a/pkg/observe/qstat/stream.go
+++ b/pkg/observe/qstat/stream.go
@@ -24,7 +24,7 @@ func stream(ctx context.Context, runnameIn string, backend be.Backend, opts Opti
 		fmt.Fprintln(os.Stderr, "Tracking run", runname)
 	}
 
-	client, err := s3.NewS3ClientForRun(ctx, backend, runname)
+	client, err := s3.NewS3ClientForRun(ctx, backend, runname, opts.LogOptions)
 	if err != nil {
 		return client.RunContext, nil, nil, nil, err
 	}

--- a/pkg/runtime/builtins/cat.go
+++ b/pkg/runtime/builtins/cat.go
@@ -27,7 +27,7 @@ func Cat(ctx context.Context, client s3.S3Client, run queue.RunContext, inputs [
 }
 
 func CatClient(ctx context.Context, backend be.Backend, run queue.RunContext, inputs []string, opts build.LogOptions) error {
-	client, err := s3.NewS3ClientForRun(ctx, backend, run.RunName)
+	client, err := s3.NewS3ClientForRun(ctx, backend, run.RunName, opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/runtime/queue/client.go
+++ b/pkg/runtime/queue/client.go
@@ -10,6 +10,7 @@ import (
 
 	"lunchpail.io/pkg/be"
 	"lunchpail.io/pkg/be/runs/util"
+	"lunchpail.io/pkg/build"
 	"lunchpail.io/pkg/ir/queue"
 )
 
@@ -68,7 +69,7 @@ func NewS3ClientFromOptions(ctx context.Context, opts S3ClientOptions) (S3Client
 }
 
 // Client for a given run in the given backend
-func NewS3ClientForRun(ctx context.Context, backend be.Backend, runname string) (S3ClientStop, error) {
+func NewS3ClientForRun(ctx context.Context, backend be.Backend, runname string, opts build.LogOptions) (S3ClientStop, error) {
 	if runname == "" {
 		run, err := util.Singleton(ctx, backend)
 		if err != nil {
@@ -77,7 +78,7 @@ func NewS3ClientForRun(ctx context.Context, backend be.Backend, runname string) 
 		runname = run.Name
 	}
 
-	endpoint, accessKeyId, secretAccessKey, bucket, stop, err := backend.AccessQueue(ctx, queue.RunContext{RunName: runname})
+	endpoint, accessKeyId, secretAccessKey, bucket, stop, err := backend.AccessQueue(ctx, queue.RunContext{RunName: runname}, opts)
 	if err != nil {
 		return S3ClientStop{}, err
 	}

--- a/pkg/runtime/queue/drain.go
+++ b/pkg/runtime/queue/drain.go
@@ -6,17 +6,18 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"lunchpail.io/pkg/be"
+	"lunchpail.io/pkg/build"
 	"lunchpail.io/pkg/ir/queue"
 )
 
 // Drain the output tasks, allowing graceful termination
-func Drain(ctx context.Context, backend be.Backend, run queue.RunContext) error {
-	c, err := NewS3ClientForRun(ctx, backend, run.RunName)
+func Drain(ctx context.Context, backend be.Backend, run queue.RunContext, opts build.LogOptions) error {
+	c, err := NewS3ClientForRun(ctx, backend, run.RunName, opts)
 	if err != nil {
 		return err
 	}
 	defer c.Stop()
-	run.Bucket = c.Paths.Bucket // TODO
+	run.Bucket = c.RunContext.Bucket // TODO
 
 	outbox := run.AsFile(queue.AssignedAndFinished)
 

--- a/pkg/runtime/queue/ls.go
+++ b/pkg/runtime/queue/ls.go
@@ -5,11 +5,12 @@ import (
 	"strings"
 
 	"lunchpail.io/pkg/be"
+	"lunchpail.io/pkg/build"
 	"lunchpail.io/pkg/ir/queue"
 )
 
-func Ls(ctx context.Context, backend be.Backend, run queue.RunContext, path string) (<-chan string, <-chan error, error) {
-	c, err := NewS3ClientForRun(ctx, backend, run.RunName)
+func Ls(ctx context.Context, backend be.Backend, run queue.RunContext, path string, opts build.LogOptions) (<-chan string, <-chan error, error) {
+	c, err := NewS3ClientForRun(ctx, backend, run.RunName, opts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/runtime/queue/qcat.go
+++ b/pkg/runtime/queue/qcat.go
@@ -5,11 +5,12 @@ import (
 	"path/filepath"
 
 	"lunchpail.io/pkg/be"
+	"lunchpail.io/pkg/build"
 	"lunchpail.io/pkg/ir/queue"
 )
 
-func Qcat(ctx context.Context, backend be.Backend, run queue.RunContext, path string) error {
-	c, err := NewS3ClientForRun(ctx, backend, run.RunName)
+func Qcat(ctx context.Context, backend be.Backend, run queue.RunContext, path string, opts build.LogOptions) error {
+	c, err := NewS3ClientForRun(ctx, backend, run.RunName, opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/runtime/queue/upload.go
+++ b/pkg/runtime/queue/upload.go
@@ -11,17 +11,18 @@ import (
 	"time"
 
 	"lunchpail.io/pkg/be"
+	"lunchpail.io/pkg/build"
 	"lunchpail.io/pkg/ir/queue"
 	"lunchpail.io/pkg/runtime/queue/upload"
 )
 
-func UploadFiles(ctx context.Context, backend be.Backend, run queue.RunContext, specs []upload.Upload) error {
-	s3, err := NewS3ClientForRun(ctx, backend, run.RunName)
+func UploadFiles(ctx context.Context, backend be.Backend, run queue.RunContext, specs []upload.Upload, opts build.LogOptions) error {
+	s3, err := NewS3ClientForRun(ctx, backend, run.RunName, opts)
 	if err != nil {
 		return err
 	}
 	defer s3.Stop()
-	run.Bucket = s3.Paths.Bucket // TODO
+	run.Bucket = s3.RunContext.Bucket // TODO
 
 	for _, spec := range specs {
 		fmt.Fprintf(os.Stderr, "Preparing upload with mkdirp on s3 bucket=%s\n", spec.Bucket)


### PR DESCRIPTION
This touches a lot of files, because we have updated `be.Backend.AccessQueue()` to require a `build.LogOptions`. This also removes `be.Backend.Queue()` from the public API.