### PR TITLE
fix: various fixes for non-minio s3 endpoints

### DIFF
--- a/pkg/boot/failures.go
+++ b/pkg/boot/failures.go
@@ -2,6 +2,7 @@ package boot
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -35,7 +36,7 @@ func lookForTaskFailures(ctx context.Context, backend be.Backend, run queue.RunC
 		case err := <-errc:
 			if err == nil || strings.Contains(err.Error(), "EOF") || strings.Contains(err.Error(), "connection refused") {
 				done = true
-			} else {
+			} else if !errors.Is(err, s3.ListenNotSupportedError) {
 				fmt.Fprintln(os.Stderr, err)
 			}
 		case object := <-objc:

--- a/pkg/runtime/builtins/redirect.go
+++ b/pkg/runtime/builtins/redirect.go
@@ -2,6 +2,7 @@ package builtins
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -57,7 +58,7 @@ func RedirectTo(ctx context.Context, client s3.S3Client, run queue.RunContext, f
 		case err := <-outboxErrs:
 			if err == nil || strings.Contains(err.Error(), "EOF") {
 				done = true
-			} else {
+			} else if !errors.Is(err, s3.ListenNotSupportedError) {
 				fmt.Fprintln(os.Stderr, err)
 			}
 		case object := <-outboxObjects:

--- a/pkg/runtime/queue/client.go
+++ b/pkg/runtime/queue/client.go
@@ -19,6 +19,8 @@ type S3Client struct {
 	client   *minio.Client
 	endpoint string
 	Paths    filepaths
+	ak       string
+	sk       string
 }
 
 type S3ClientStop struct {
@@ -65,7 +67,7 @@ func NewS3ClientFromOptions(ctx context.Context, opts S3ClientOptions) (S3Client
 		return S3Client{}, err
 	}
 
-	return S3Client{ctx, client, opts.Endpoint, paths}, nil
+	return S3Client{ctx, client, opts.Endpoint, paths, opts.AccessKeyID, opts.SecretAccessKey}, nil
 }
 
 // Client for a given run in the given backend

--- a/pkg/runtime/queue/upload.go
+++ b/pkg/runtime/queue/upload.go
@@ -76,6 +76,12 @@ func (s3 S3Client) copyInDir(bucket string, spec upload.Upload, opts build.LogOp
 
 func (s3 S3Client) copyInFile(bucket, localPath string, spec upload.Upload, opts build.LogOptions) error {
 	for i := range 10 {
+		select {
+		case <-s3.context.Done():
+			return nil
+		default:
+		}
+
 		var dst string
 		switch spec.TargetDir {
 		case "":

--- a/pkg/runtime/worker/watcher.go
+++ b/pkg/runtime/worker/watcher.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -76,10 +77,12 @@ func startWatch(ctx context.Context, handler []string, client s3.S3Client, opts 
 
 		select {
 		case err := <-errs:
-			if opts.LogOptions.Verbose {
-				fmt.Fprintln(os.Stderr, err)
+			if err != nil && !errors.Is(err, s3.ListenNotSupportedError) {
+				if opts.LogOptions.Verbose {
+					fmt.Fprintln(os.Stderr, err)
+				}
+				sleepNextTime = true
 			}
-			sleepNextTime = true
 
 		case task := <-tasks:
 			if task != "" {

--- a/pkg/runtime/workstealer/assess.go
+++ b/pkg/runtime/workstealer/assess.go
@@ -208,9 +208,7 @@ func (c client) rebalance(m queuestreamer.Step) bool {
 func (c client) touchKillFiles(m queuestreamer.Step) {
 	for _, worker := range m.LiveWorkers {
 		if !worker.KillfilePresent {
-			if c.LogOptions.Verbose {
-				fmt.Fprintf(os.Stderr, "Touching kill file for step=%d pool=%s worker=%s\n", m.Index, worker.Pool, worker.Name)
-			}
+			fmt.Fprintf(os.Stderr, "Touching kill file for step=%d pool=%s worker=%s\n", m.Index, worker.Pool, worker.Name)
 			if err := c.touchKillFile(m.Index, worker); err != nil {
 				fmt.Fprintln(os.Stderr, err.Error())
 			}

--- a/pkg/runtime/workstealer/run.go
+++ b/pkg/runtime/workstealer/run.go
@@ -105,9 +105,7 @@ func Run(ctx context.Context, run queue.RunContext, opts Options) error {
 	// Drop a final breadcrumb indicating we are ready to tear
 	// down all associated resources
 	if opts.SelfDestruct {
-		if opts.Verbose {
-			fmt.Fprintf(os.Stderr, "Instructing the run to self-destruct bucket=%s file=%s\n", c.RunContext.Bucket, c.RunContext.AsFile(queue.AllDoneMarker))
-		}
+		fmt.Fprintf(os.Stderr, "Instructing the run to self-destruct bucket=%s file=%s\n", c.RunContext.Bucket, c.RunContext.AsFile(queue.AllDoneMarker))
 		if err := s3.Touch(c.RunContext.Bucket, c.RunContext.AsFile(queue.AllDoneMarker)); err != nil {
 			fmt.Fprintf(os.Stderr, "Unable to touch AllDone file\n%v\n", err)
 		}


### PR DESCRIPTION
- improved detection of errors from ibmcloud
- boot/up had assumed that the minio component would disappear as part of its cleanup logic
- clean up boot/alldone to call the simpler WaitTillExists() API
- a few other bug fixes in the way the polling varying of Listen() API worked; e.g. we weren't properly avoiding re-notifying on existing objects when polling