### PR TITLE
fix: multiple bugs for mixed local-kubernetes pipelines

### DIFF
--- a/cmd/subcommands/component/worker/prestop.go
+++ b/cmd/subcommands/component/worker/prestop.go
@@ -17,6 +17,10 @@ func PreStop() *cobra.Command {
 		Long:  "Mark this worker as dead",
 	}
 
+	var step int
+	cmd.Flags().IntVar(&step, "step", step, "Which step are we part of")
+	cmd.MarkFlagRequired("step")
+
 	var poolName string
 	cmd.Flags().StringVar(&poolName, "pool", "", "Which worker pool are we part of")
 	cmd.MarkFlagRequired("pool")
@@ -35,7 +39,7 @@ func PreStop() *cobra.Command {
 
 		return worker.PreStop(context.Background(), worker.Options{
 			LogOptions: *logOpts,
-			RunContext: run.ForPool(poolName).ForWorker(workerName),
+			RunContext: run.ForStep(step).ForPool(poolName).ForWorker(workerName),
 		})
 	}
 

--- a/cmd/subcommands/component/worker/run.go
+++ b/cmd/subcommands/component/worker/run.go
@@ -19,6 +19,10 @@ func Run() *cobra.Command {
 		Args:  cobra.MatchAll(cobra.OnlyValidArgs),
 	}
 
+	var step int
+	cmd.Flags().IntVar(&step, "step", step, "Which step are we part of")
+	cmd.MarkFlagRequired("step")
+
 	var poolName string
 	cmd.Flags().StringVar(&poolName, "pool", "", "Which worker pool are we part of")
 	cmd.MarkFlagRequired("pool")
@@ -51,7 +55,7 @@ func Run() *cobra.Command {
 			StartupDelay:      startupDelay,
 			PollingInterval:   pollingInterval,
 			LogOptions:        *logOpts,
-			RunContext:        run.ForPool(poolName).ForWorker(workerName),
+			RunContext:        run.ForStep(step).ForPool(poolName).ForWorker(workerName),
 		})
 	}
 

--- a/hack/pipeline-demo.sh
+++ b/hack/pipeline-demo.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 SCRIPTDIR=$(cd $(dirname "$0") && pwd)
 TOP="$SCRIPTDIR"/..
 
-lp=./lunchpail
+lp=/tmp/lunchpail
 if [ ! -e $lp ]
 then "$TOP"/hack/setup/cli.sh $lp
 fi
@@ -19,11 +19,70 @@ export LUNCHPAIL_TARGET=${LUNCHPAIL_TARGET:-local}
 
 stepo=./pipeline-demo
 if [ ! -e $stepo ]
-then ./lunchpail build --create-namespace -e 'echo "hi from step $LUNCHPAIL_STEP"; sleep 2' -o $stepo
+then $lp build --create-namespace -e 'echo "hi from step $LUNCHPAIL_STEP"; sleep 2' -o $stepo
 fi
 
-step="$stepo up --verbose=${VERBOSE:-false} --workers 3 --queue rclone://cfp/lunchpail"
+export RCLONE_CONFIG=$(mktemp)
+QUEUE_BUCKET=pipeline-demo
+MINIO_DATA_DIR=./data-$(date +%s)
+
+PATH=$($lp needs minio):$PATH
+
+export MINIO_ROOT_USER=lunchpail
+export MINIO_ROOT_PASSWORD=lunchpail
+
+MINIO_PORT=57331
+minio server --address :$MINIO_PORT $MINIO_DATA_DIR &
+MINIO_PID=$!
+trap "kill $MINIO_PID; rm -f $RCLONE_CONFIG; rm -rf $MINIO_DATA_DIR" EXIT
+
+if [[ $(uname) = Darwin ]]
+then HOST_IP=host.docker.internal
+else
+    HOST_IP=172.17.0.1
+    cat <<EOF > /tmp/kindhack.yaml
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  apiServerAddress: "0.0.0.0"
+EOF
+fi
+
+cat <<EOF > $RCLONE_CONFIG
+[lunchpail]
+type = s3
+provider = Other
+env_auth = false
+endpoint = http://localhost:$MINIO_PORT
+access_key_id = $MINIO_ROOT_USER
+secret_access_key = $MINIO_ROOT_PASSWORD
+acl = public-read
+
+[lunchpailk]
+type = s3
+provider = Other
+env_auth = false
+endpoint = http://$HOST_IP:$MINIO_PORT
+access_key_id = $MINIO_ROOT_USER
+secret_access_key = $MINIO_ROOT_PASSWORD
+acl = public-read
+EOF
+
+if [[ -n "$CI" ]]
+then VERBOSE=true
+fi
+
+step="$stepo up --verbose=${VERBOSE:-false} --workers 3"
+
+# local
+stepl="$step -t local --queue rclone://lunchpail/$QUEUE_BUCKET"
+
+# kubernetes?
+if [[ "$LUNCHPAIL_TARGET" = "kubernetes" ]]
+then stepk="$step -t kubernetes --queue rclone://lunchpailk/$QUEUE_BUCKET"
+else stepk="$stepl" # if we are not intentionally testing kubernetes, then use local here, too
+fi
 
 echo "Launching pipeline"
-$step <(echo in1) <(echo in2) <(echo in3) <(echo in4) <(echo in5) <(echo in6) <(echo in7) <(echo in8) <(echo in9) <(echo in10) <(echo in11) <(echo in12) <(echo in13) <(echo in14) <(echo in15) <(echo in16) \
-    | $step | $step | $step | $step | $step | $step | $step
+$stepl <(echo in1) <(echo in2) <(echo in3) <(echo in4) <(echo in5) <(echo in6) <(echo in7) <(echo in8) <(echo in9) <(echo in10) <(echo in11) <(echo in12) <(echo in13) <(echo in14) <(echo in15) <(echo in16) \
+    | $stepk | $stepl | $stepk | $stepl | $stepl | $stepl | $stepl

--- a/pkg/be/backend.go
+++ b/pkg/be/backend.go
@@ -13,7 +13,7 @@ import (
 
 type Backend interface {
 	// Is the backend ready for `up`?
-	Ok(ctx context.Context, initOk bool) error
+	Ok(ctx context.Context, initOk bool, opts build.Options) error
 
 	// Bring up the linked application
 	Up(ctx context.Context, linked llir.LLIR, opts llir.Options, isRunning chan llir.Context) error

--- a/pkg/be/ibmcloud/ok.go
+++ b/pkg/be/ibmcloud/ok.go
@@ -4,11 +4,13 @@ import (
 	"context"
 
 	"github.com/IBM/vpc-go-sdk/vpcv1"
+
+	"lunchpail.io/pkg/build"
 )
 
 // Validate that our vpc service works
 // TODO: this should accept no arguments and be a method on an instance that we return
-func (backend Backend) Ok(ctx context.Context, initOk bool) error {
+func (backend Backend) Ok(ctx context.Context, initOk bool, opts build.Options) error {
 	limit := int64(1)
 	resourceGroupId := backend.config.ResourceGroup.GUID
 

--- a/pkg/be/kubernetes/ok.go
+++ b/pkg/be/kubernetes/ok.go
@@ -9,13 +9,14 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/tools/clientcmd"
 
+	"lunchpail.io/pkg/build"
 	initialize "lunchpail.io/pkg/lunchpail/init"
 )
 
-func (backend Backend) Ok(ctx context.Context, initOk bool) error {
+func (backend Backend) Ok(ctx context.Context, initOk bool, opts build.Options) error {
 	announcedWait := false
 	for {
-		if err := backend.ok(ctx, initOk); err != nil {
+		if err := backend.ok(ctx, initOk, opts); err != nil {
 			if !initOk && clientcmd.IsEmptyConfig(err) {
 				if !announcedWait {
 					announcedWait = true
@@ -34,12 +35,12 @@ func (backend Backend) Ok(ctx context.Context, initOk bool) error {
 	return nil
 }
 
-func (backend Backend) ok(ctx context.Context, initOk bool) error {
+func (backend Backend) ok(ctx context.Context, initOk bool, opts build.Options) error {
 	_, config, err := Client()
 	if err != nil {
 		if clientcmd.IsEmptyConfig(err) && initOk {
 			if ok, buildImages := userIsOkWithInit(); ok {
-				return initialize.Local(ctx, initialize.InitLocalOptions{BuildImages: buildImages})
+				return initialize.Local(ctx, initialize.InitLocalOptions{BuildImages: buildImages, Verbose: opts.Log.Verbose})
 			}
 			return err
 		}

--- a/pkg/be/kubernetes/queue.go
+++ b/pkg/be/kubernetes/queue.go
@@ -23,6 +23,9 @@ func (backend Backend) AccessQueue(ctx context.Context, run queue.RunContext, op
 		return
 	}
 
+	// we may override this below, if we open a portforward
+	stop = func() {}
+
 	if strings.Contains(endpoint, "cluster.local") {
 		// Then the queue is running inside the cluster. We
 		// will need to open a port forward.

--- a/pkg/be/local/ok.go
+++ b/pkg/be/local/ok.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 
 	"lunchpail.io/pkg/be/local/shell"
+	"lunchpail.io/pkg/build"
 	"lunchpail.io/pkg/ir/llir"
 )
 
 // Is the backend ready for `up`?
-func (backend Backend) Ok(ctx context.Context, initOk bool) error {
+func (backend Backend) Ok(ctx context.Context, initOk bool, opts build.Options) error {
 	return nil
 }
 

--- a/pkg/be/new.go
+++ b/pkg/be/new.go
@@ -32,7 +32,7 @@ func NewInitOk(ctx context.Context, initOk bool, opts build.Options) (Backend, e
 		return nil, err
 	}
 
-	if err := be.Ok(ctx, initOk); err != nil {
+	if err := be.Ok(ctx, initOk, opts); err != nil {
 		return nil, err
 	}
 

--- a/pkg/boot/alldone.go
+++ b/pkg/boot/alldone.go
@@ -13,7 +13,7 @@ import (
 )
 
 func waitForAllDone(ctx context.Context, backend be.Backend, run queue.RunContext, opts build.LogOptions) error {
-	client, err := s3.NewS3ClientForRun(ctx, backend, run.RunName, opts)
+	client, err := s3.NewS3ClientForRun(ctx, backend, run, opts)
 	if err != nil {
 		if strings.Contains(err.Error(), "Connection closed") {
 			// already gone
@@ -21,15 +21,14 @@ func waitForAllDone(ctx context.Context, backend be.Backend, run queue.RunContex
 		}
 		return err
 	}
-	run.Bucket = client.RunContext.Bucket
 	defer client.Stop()
 
-	if err := client.WaitTillExists(run.Bucket, run.AsFile(queue.AllDoneMarker)); err != nil {
+	if err := client.WaitTillExists(client.RunContext.Bucket, client.RunContext.AsFile(queue.AllDoneMarker)); err != nil {
 		return err
 	}
 
 	if opts.Verbose {
-		fmt.Fprintln(os.Stderr, "Got all done. Cleaning up", run.Step)
+		fmt.Fprintln(os.Stderr, "Got all done. Cleaning up", client.RunContext.Step)
 	}
 	return nil
 }

--- a/pkg/boot/failures.go
+++ b/pkg/boot/failures.go
@@ -14,11 +14,11 @@ import (
 )
 
 func lookForTaskFailures(ctx context.Context, backend be.Backend, run queue.RunContext, opts build.LogOptions) error {
-	client, err := s3.NewS3ClientForRun(ctx, backend, run.RunName, opts)
+	client, err := s3.NewS3ClientForRun(ctx, backend, run, opts)
 	if err != nil {
 		return err
 	}
-	run.Bucket = client.RunContext.Bucket
+	run = client.RunContext
 	defer client.Stop()
 
 	if err := client.Mkdirp(run.Bucket); err != nil {

--- a/pkg/fe/prepare-run.go
+++ b/pkg/fe/prepare-run.go
@@ -93,7 +93,7 @@ func PrepareHLIRForRun(ir hlir.HLIR, ctx llir.Context, popts PrepareOptions, opt
 		}
 	}
 
-	if ctx.Queue.Endpoint == "" {
+	if opts.Queue != "" || ctx.Queue.Endpoint == "" {
 		spec, err := q.ParseFlag(opts.Queue, ctx.Run.RunName)
 		if err != nil {
 			return llir.LLIR{}, err

--- a/pkg/lunchpail/init/kind.go
+++ b/pkg/lunchpail/init/kind.go
@@ -57,6 +57,13 @@ func createKindCluster() error {
 	if err := cmd.Run(); err != nil {
 		args := []string{"create", "cluster", "--wait", "10m", "--name", lunchpail.LocalClusterName}
 
+		// allows selectively hacking kind cluster config
+		if _, err := os.Stat("/tmp/kindhack.yaml"); err == nil {
+			fmt.Println("Hacking kind cluster config")
+			args = append(args, "--config")
+			args = append(args, "/tmp/kindhack.yaml")
+		}
+
 		fmt.Fprintf(os.Stderr, "Creating kind cluster %s\n", lunchpail.LocalClusterName)
 
 		cmd := exec.Command("kind", args...)

--- a/pkg/observe/qstat/stream.go
+++ b/pkg/observe/qstat/stream.go
@@ -24,7 +24,7 @@ func stream(ctx context.Context, runnameIn string, backend be.Backend, opts Opti
 		fmt.Fprintln(os.Stderr, "Tracking run", runname)
 	}
 
-	client, err := s3.NewS3ClientForRun(ctx, backend, runname, opts.LogOptions)
+	client, err := s3.NewS3ClientForRun(ctx, backend, queue.RunContext{RunName: runname}, opts.LogOptions)
 	if err != nil {
 		return client.RunContext, nil, nil, nil, err
 	}

--- a/pkg/runtime/builtins/cat.go
+++ b/pkg/runtime/builtins/cat.go
@@ -27,7 +27,7 @@ func Cat(ctx context.Context, client s3.S3Client, run queue.RunContext, inputs [
 }
 
 func CatClient(ctx context.Context, backend be.Backend, run queue.RunContext, inputs []string, opts build.LogOptions) error {
-	client, err := s3.NewS3ClientForRun(ctx, backend, run.RunName, opts)
+	client, err := s3.NewS3ClientForRun(ctx, backend, run, opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/runtime/builtins/redirect.go
+++ b/pkg/runtime/builtins/redirect.go
@@ -17,7 +17,11 @@ import (
 
 func RedirectTo(ctx context.Context, client s3.S3Client, run queue.RunContext, folderFor func(object string) string, opts build.LogOptions) error {
 	outbox := run.AsFile(queue.AssignedAndFinished)
-	outboxObjects, outboxErrs := client.Listen(client.Paths.Bucket, outbox, "", false)
+	outboxObjects, outboxErrs := client.Listen(run.Bucket, outbox, "", false)
+
+	if opts.Verbose {
+		fmt.Fprintf(os.Stderr, "Redirect listening on bucket=%s path=%s\n", run.Bucket, outbox)
+	}
 
 	group, _ := errgroup.WithContext(ctx)
 	done := false
@@ -32,7 +36,7 @@ func RedirectTo(ctx context.Context, client s3.S3Client, run queue.RunContext, f
 			if opts.Verbose {
 				fmt.Fprintf(os.Stderr, "Downloading output %s to %s\n", object, dst)
 			}
-			if err := client.Download(client.Paths.Bucket, object, dst); err != nil {
+			if err := client.Download(run.Bucket, object, dst); err != nil {
 				if opts.Verbose {
 					fmt.Fprintf(os.Stderr, "Error downloading output %s\n%v\n", object, err)
 				}

--- a/pkg/runtime/minio/server.go
+++ b/pkg/runtime/minio/server.go
@@ -97,7 +97,7 @@ func Server(ctx context.Context, port int, run queue.RunContext) error {
 		}
 	}
 
-	fmt.Fprintf(os.Stderr, "Exiting\n")
+	fmt.Fprintf(os.Stderr, "Minio Exiting\n")
 	return nil
 }
 

--- a/pkg/runtime/queue/drain.go
+++ b/pkg/runtime/queue/drain.go
@@ -12,7 +12,7 @@ import (
 
 // Drain the output tasks, allowing graceful termination
 func Drain(ctx context.Context, backend be.Backend, run queue.RunContext, opts build.LogOptions) error {
-	c, err := NewS3ClientForRun(ctx, backend, run.RunName, opts)
+	c, err := NewS3ClientForRun(ctx, backend, run, opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/runtime/queue/ls.go
+++ b/pkg/runtime/queue/ls.go
@@ -11,7 +11,7 @@ import (
 )
 
 func Ls(ctx context.Context, backend be.Backend, run queue.RunContext, path string, opts build.LogOptions) (<-chan string, <-chan error, error) {
-	c, err := NewS3ClientForRun(ctx, backend, run.RunName, opts)
+	c, err := NewS3ClientForRun(ctx, backend, run, opts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/runtime/queue/qcat.go
+++ b/pkg/runtime/queue/qcat.go
@@ -10,7 +10,7 @@ import (
 )
 
 func Qcat(ctx context.Context, backend be.Backend, run queue.RunContext, path string, opts build.LogOptions) error {
-	c, err := NewS3ClientForRun(ctx, backend, run.RunName, opts)
+	c, err := NewS3ClientForRun(ctx, backend, run, opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/runtime/queue/qdone.go
+++ b/pkg/runtime/queue/qdone.go
@@ -12,7 +12,7 @@ import (
 // Indicate dispatching is done, with given client
 func QdoneClient(ctx context.Context, c S3Client, run queue.RunContext, opts build.LogOptions) (err error) {
 	if opts.Verbose {
-		fmt.Fprintf(os.Stderr, "Done with dispatching\n")
+		fmt.Fprintf(os.Stderr, "Done with dispatching step=%d\n", run.Step)
 	}
 
 	if err := c.Mkdirp(run.Bucket); err != nil {

--- a/pkg/runtime/queue/upload.go
+++ b/pkg/runtime/queue/upload.go
@@ -16,7 +16,7 @@ import (
 )
 
 func UploadFiles(ctx context.Context, backend be.Backend, run queue.RunContext, specs []upload.Upload, opts build.LogOptions) error {
-	s3, err := NewS3ClientForRun(ctx, backend, run.RunName, opts)
+	s3, err := NewS3ClientForRun(ctx, backend, run, opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/runtime/worker/prestop.go
+++ b/pkg/runtime/worker/prestop.go
@@ -26,7 +26,7 @@ func PreStop(ctx context.Context, opts Options) error {
 	}
 
 	if opts.LogOptions.Verbose {
-		fmt.Fprintf(os.Stderr, "This worker is shutting down pool=%s worker=%s\n", opts.RunContext.PoolName, opts.RunContext.WorkerName)
+		fmt.Fprintf(os.Stderr, "This worker is shutting down step=%d pool=%s worker=%s\n", opts.RunContext.Step, opts.RunContext.PoolName, opts.RunContext.WorkerName)
 	}
 
 	return nil

--- a/pkg/runtime/worker/run.go
+++ b/pkg/runtime/worker/run.go
@@ -17,7 +17,7 @@ func printenv() {
 
 func Run(ctx context.Context, handler []string, opts Options) error {
 	if opts.LogOptions.Verbose {
-		fmt.Fprintf(os.Stderr, "Worker starting up run=%s bucket=%s pool=%s worker=%s\n", opts.RunContext.RunName, opts.RunContext.Bucket, opts.RunContext.PoolName, opts.RunContext.WorkerName)
+		fmt.Fprintf(os.Stderr, "Worker starting up run=%s step=%d pool=%s worker=%s\n", opts.RunContext.RunName, opts.RunContext.Step, opts.RunContext.PoolName, opts.RunContext.WorkerName)
 		printenv()
 	}
 

--- a/pkg/runtime/worker/watcher.go
+++ b/pkg/runtime/worker/watcher.go
@@ -16,7 +16,9 @@ import (
 
 func startWatch(ctx context.Context, handler []string, client s3.S3Client, opts Options) error {
 	if opts.LogOptions.Verbose {
-		defer func() { fmt.Fprintln(os.Stderr, "Worker exiting") }()
+		defer func() {
+			fmt.Fprintf(os.Stderr, "Worker exiting step=%d pool=%s worker=%s\n", opts.RunContext.Step, opts.RunContext.PoolName, opts.RunContext.WorkerName)
+		}()
 	}
 
 	if err := client.Mkdirp(opts.RunContext.Bucket); err != nil {
@@ -54,7 +56,7 @@ func startWatch(ctx context.Context, handler []string, client s3.S3Client, opts 
 	go func() {
 		client.WaitTillExists(opts.RunContext.Bucket, killFile)
 		if opts.LogOptions.Verbose {
-			fmt.Fprintln(os.Stderr, "Worker got kill file. Cleaning up...")
+			fmt.Fprintf(os.Stderr, "Worker got kill file step=%d pool=%s worker=%s. Cleaning up...", opts.RunContext.Step, opts.RunContext.PoolName, opts.RunContext.WorkerName)
 		}
 		cancel()
 	}()


### PR DESCRIPTION
- updates `pipeline-demo.sh` so that when it is running in kubernetes mode, it actually does a mix of local and kubernetes
- updates `pipeline-demo.sh` to launch a separate minio, and fixed some issues with using it. this should give us some test coverage for a “remote/hosted” s3. it aws also necessary to support mixed kubernetes-local.
- fixes a couple of bugs with run context (missing step) and with this mix-mode and with pipelines versus external/hosted s3
- fixes a race condition in the workstealer caused by the use of the debouncer