### PR TITLE
fix: hack/pipeline-demo.sh ends with `INFO: Exiting on signal: TERMINATED`

### DIFF
--- a/hack/pipeline-demo.sh
+++ b/hack/pipeline-demo.sh
@@ -32,7 +32,7 @@ export MINIO_ROOT_USER=lunchpail
 export MINIO_ROOT_PASSWORD=lunchpail
 
 MINIO_PORT=57331
-minio server --address :$MINIO_PORT $MINIO_DATA_DIR &
+minio server --address :$MINIO_PORT $MINIO_DATA_DIR 2>&1 | grep -v 'Exiting on signal: TERMINATED' &
 MINIO_PID=$!
 trap "kill $MINIO_PID; rm -f $RCLONE_CONFIG; rm -rf $MINIO_DATA_DIR" EXIT
 


### PR DESCRIPTION
This is output from `minio server` resulting from pipeline-demo.sh killing it at the end.