### PR TITLE
fix: avoid multiple kubernetes Secrets storing the same data

### DIFF
--- a/pkg/be/kubernetes/common/chart/templates/default-queue.yaml
+++ b/pkg/be/kubernetes/common/chart/templates/default-queue.yaml
@@ -5,7 +5,6 @@ metadata:
   name: {{ .Values.lunchpail.taskqueue.dataset }}
   labels:
     app.kubernetes.io/component: taskqueue
-    app.kubernetes.io/instance: {{ .Release.Name }}
 type: Opaque
 stringData:
   bucket: {{ .Values.lunchpail.taskqueue.bucket }}

--- a/pkg/be/kubernetes/common/values.go
+++ b/pkg/be/kubernetes/common/values.go
@@ -11,12 +11,17 @@ import (
 func Values(ir llir.LLIR, opts Options) ([]string, error) {
 	imagePullSecretName, dockerconfigjson, err := imagePullSecret(opts.ImagePullSecret)
 	if err != nil {
-		return []string{}, err
+		return nil, err
 	}
 
 	serviceAccount := ir.RunName()
 	if !opts.NeedsServiceAccount && imagePullSecretName == "" {
 		serviceAccount = ""
+	}
+
+	queueResource, err := names.Queue(ir.Context)
+	if err != nil {
+		return nil, err
 	}
 
 	return []string{
@@ -27,7 +32,7 @@ func Values(ir llir.LLIR, opts Options) ([]string, error) {
 		fmt.Sprintf("lunchpail.namespace.create=%v", opts.CreateNamespace),
 		"lunchpail.rbac.serviceaccount=" + serviceAccount,
 		fmt.Sprintf("lunchpail.taskqueue.auto=%v", ir.Queue().Auto),
-		"lunchpail.taskqueue.dataset=" + names.Queue(ir.Context.Run),
+		"lunchpail.taskqueue.dataset=" + queueResource,
 		"lunchpail.taskqueue.endpoint=" + ir.Queue().Endpoint,
 		"lunchpail.taskqueue.bucket=" + ir.Queue().Bucket,
 		"lunchpail.taskqueue.accessKey=" + ir.Queue().AccessKey,

--- a/pkg/be/kubernetes/names/queue.go
+++ b/pkg/be/kubernetes/names/queue.go
@@ -1,18 +1,38 @@
 package names
 
 import (
+	"crypto/sha256"
+	"encoding/json"
 	"fmt"
-	"strings"
+	"os"
 
-	"lunchpail.io/pkg/ir/queue"
+	"lunchpail.io/pkg/ir/llir"
 )
+
+func QueueHash(ctx llir.Context) (string, error) {
+	hash := sha256.New()
+	if b, err := json.Marshal(ctx.Queue); err != nil {
+		return "", err
+	} else if _, err := hash.Write(b); err != nil {
+		return "", err
+	}
+
+	fmt.Fprintln(os.Stderr, "!!!!!!!!!!!!!!!!!!!!", ctx.Run.Step, ctx.Queue, fmt.Sprintf("%x", hash.Sum(nil)))
+
+	return fmt.Sprintf("%x", hash.Sum(nil)), nil
+}
 
 // This will be used to name the queue Secret and will be used as the
 // envPrefix for secrets injected into the containers. Since dashes
 // are not valid in bash variable names, so we avoid those here.
-func Queue(run queue.RunContext) string {
-	return fmt.Sprintf("%s%dqueue",
-		strings.Replace(run.RunName, "-", "", -1),
-		run.Step,
-	)
+func Queue(ctx llir.Context) (string, error) {
+	hash, err := QueueHash(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	if len(hash) > 60 {
+		hash = hash[:60]
+	}
+	return "lp-" + hash, nil
 }

--- a/pkg/be/kubernetes/shell/chart/templates/job.yaml
+++ b/pkg/be/kubernetes/shell/chart/templates/job.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/name: {{ .Values.lunchpail.instanceName }}
     app.kubernetes.io/instance: {{ .Values.lunchpail.name }}
     app.kubernetes.io/managed-by: lunchpail.io
+    lunchpail.io/queue: {{ .Values.taskqueue.secret }}
 spec:
   parallelism: {{ .Values.workers.count }}
   ttlSecondsAfterFinished: 1800 # the pods will go away 30 minutes after completion

--- a/pkg/be/kubernetes/shell/template.go
+++ b/pkg/be/kubernetes/shell/template.go
@@ -56,6 +56,11 @@ func Template(ir llir.LLIR, c llir.ShellComponent, namespace string, opts common
 		groupName = c.InstanceName
 	}
 
+	queueResource, err := names.Queue(ir.Context)
+	if err != nil {
+		return "", err
+	}
+
 	// values for this component
 	myValues := []string{
 		fmt.Sprintf("lunchpail.step=%d", ir.Context.Run.Step),
@@ -73,6 +78,7 @@ func Template(ir llir.LLIR, c llir.ShellComponent, namespace string, opts common
 		"securityContext=" + securityContext,
 		"containerSecurityContext=" + containerSecurityContext,
 		"taskqueue.bucket=" + ir.Queue().Bucket,
+		"taskqueue.secret=" + queueResource,
 		"volumes=" + volumes,
 		"volumeMounts=" + volumeMounts,
 		"initContainers=" + initContainers,

--- a/pkg/fe/linker/queue/rclone.go
+++ b/pkg/fe/linker/queue/rclone.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 
 	rcloneConfig "github.com/rclone/rclone/fs/config"
@@ -34,6 +35,14 @@ func SpecFromRcloneRemoteName(remoteName, bucket, runname string, internalS3Port
 		return false, queue.Spec{}, fmt.Errorf("Rclone config '%s' has invalid endpoint value: '%s'", remoteName, maybe)
 	} else {
 		spec.Endpoint = s
+		words := strings.Split(spec.Endpoint, ":")
+		if len(words) == 3 {
+			p, err := strconv.Atoi(words[2])
+			if err != nil {
+				return false, queue.Spec{}, err
+			}
+			spec.Port = p
+		}
 		if !isInternalS3(s) {
 			spec.Auto = false
 		}

--- a/pkg/ir/llir/context.go
+++ b/pkg/ir/llir/context.go
@@ -1,0 +1,16 @@
+package llir
+
+import "lunchpail.io/pkg/ir/queue"
+
+type Context struct {
+	Run   queue.RunContext
+	Queue queue.Spec
+}
+
+func (ir LLIR) RunName() string {
+	return ir.Context.Run.RunName
+}
+
+func (ir LLIR) Queue() queue.Spec {
+	return ir.Context.Queue
+}

--- a/pkg/ir/llir/llir.go
+++ b/pkg/ir/llir/llir.go
@@ -1,9 +1,6 @@
 package llir
 
-import (
-	"lunchpail.io/pkg/ir/queue"
-	"lunchpail.io/pkg/lunchpail"
-)
+import "lunchpail.io/pkg/lunchpail"
 
 // One Component for WorkStealer, one for Dispatcher, and each per WorkerPool
 type Component interface {
@@ -12,11 +9,6 @@ type Component interface {
 	Workers() int
 
 	SetWorkers(w int) Component
-}
-
-type Context struct {
-	Run   queue.RunContext
-	Queue queue.Spec
 }
 
 type LLIR struct {
@@ -41,12 +33,4 @@ func (ir LLIR) HasDispatcher() bool {
 	}
 
 	return false
-}
-
-func (ir LLIR) RunName() string {
-	return ir.Context.Run.RunName
-}
-
-func (ir LLIR) Queue() queue.Spec {
-	return ir.Context.Queue
 }


### PR DESCRIPTION
e.g. in a pipeline, if multiple stages all point to the same queue, we had been creating one kubernetes secret for each. With this update, the secret name is instead based on a hash of the queue spec.