### PR TITLE
test: update to actions/cache@v4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5
     - name: Cache minio
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cache-minio
       with:
         path: /home/runner/.cache/lunchpail/bin


### PR DESCRIPTION
Fixes this warning:
> The following actions use a deprecated Node.js version