### PR TITLE
feat: pass in a lockfile to workers

### DIFF
--- a/tests/tests/python-language-pdf2parquet/settings.sh
+++ b/tests/tests/python-language-pdf2parquet/settings.sh
@@ -4,4 +4,4 @@ expected=("Done with nrows=1 nsuccess=1 nfail=0 nskip=0" "Done with nrows=2 nsuc
 NUM_DESIRED_OUTPUTS=0
 
 # --pack=1 because FileNotFoundError: [Errno 2] No such file or directory: '/home/runner/.EasyOCR//model/temp.zip'
-up_args='--pack=1 "$TEST_PATH"/pail/test-data/input/redp5110-ch1.pdf "$TEST_PATH"/pail/test-data/input/archive1.zip'
+up_args='"$TEST_PATH"/pail/test-data/input/redp5110-ch1.pdf "$TEST_PATH"/pail/test-data/input/archive1.zip'


### PR DESCRIPTION
Update python-language-pdf2parquet to use it, avoiding the need for --pack=1