### PR TITLE
fix: wrap venv installation with an flock LOCK_EX

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,6 +62,7 @@ jobs:
     - name: Run Test with args ${{ matrix.ARGS }}
       env:
         TERM: xterm-256color
+        VERBOSE: false
         LUNCHPAIL_TARGET: ${{ matrix.LUNCHPAIL_TARGET }}
         LUNCHPAIL_BUILD_NOT_NEEDED: true # we did this in the "Build Lunchpail CLI" step above
       run: bash -c "${{matrix.SCRIPT}} ${{matrix.ARGS }}"

--- a/pkg/be/kubernetes/shell/chart/templates/containers/main.yaml
+++ b/pkg/be/kubernetes/shell/chart/templates/containers/main.yaml
@@ -13,6 +13,8 @@
     - name: DEBUG
       value: "true"
     {{- end }}
+    - name: LUNCHPAIL_NO_CACHE
+      value: "true"
     - name: LUNCHPAIL_POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/lunchpail/init/kind.go
+++ b/pkg/lunchpail/init/kind.go
@@ -52,10 +52,14 @@ func getKind() error {
 	return nil
 }
 
-func createKindCluster() error {
+func createKindCluster(opts InitLocalOptions) error {
 	cmd := exec.Command("sh", "-c", "kind get clusters | grep -q "+lunchpail.LocalClusterName)
 	if err := cmd.Run(); err != nil {
 		args := []string{"create", "cluster", "--wait", "10m", "--name", lunchpail.LocalClusterName}
+
+		if !opts.Verbose {
+			args = append(args, "-q")
+		}
 
 		// allows selectively hacking kind cluster config
 		if _, err := os.Stat("/tmp/kindhack.yaml"); err == nil {

--- a/pkg/lunchpail/init/local.go
+++ b/pkg/lunchpail/init/local.go
@@ -27,7 +27,7 @@ func Local(ctx context.Context, opts InitLocalOptions) error {
 		if err := getKind(); err != nil {
 			return err
 		}
-		return createKindCluster()
+		return createKindCluster(opts)
 	})
 
 	errs.Go(func() error {

--- a/tests/bin/build.sh
+++ b/tests/bin/build.sh
@@ -36,7 +36,7 @@ repo_secret="" # e.g. user:pat@https://github.mycompany.com
 # intentionally setting some critical values at build time to the
 # final value, and some critical values to bogus values that are then
 # overridden by final values at shrinkwrap time
-/tmp/lunchpail build -v \
+/tmp/lunchpail build --verbose=${VERBOSE:-false} \
                -o $testapp.tmp \
                $branch \
                $repo_secret \

--- a/tests/bin/ci.sh
+++ b/tests/bin/ci.sh
@@ -21,8 +21,10 @@ TOP="$SCRIPTDIR"/../..
 # On ctrl+c, kill the subprocesses that may have launched
 trap "pkill -P $$" SIGINT SIGTERM
 
+echo "Starting CI tests with VERBOSE=${VERBOSE:=false}"
+
 if [[ ${LUNCHPAIL_TARGET:-kubernetes} = kubernetes ]]
-then /tmp/lunchpail dev init local --build-images --verbose
+then /tmp/lunchpail dev init local --build-images --verbose=${VERBOSE:=false}
 fi
 
 #

--- a/tests/bin/pipelines.sh
+++ b/tests/bin/pipelines.sh
@@ -17,9 +17,7 @@ trap "rm -f $IN1 $fail $add1b $add1c $add1d" EXIT
 export LUNCHPAIL_NAME="pipeline-test"
 export LUNCHPAIL_TARGET=${LUNCHPAIL_TARGET:-local}
 
-if [[ -n "$CI" ]]
-then VERBOSE="--verbose"
-fi
+VERBOSE="--verbose=${VERBOSE:-false}"
 
 if [[ $(uname) = Linux ]]
 then

--- a/tests/bin/undeploy-tests.sh
+++ b/tests/bin/undeploy-tests.sh
@@ -23,12 +23,12 @@ echo "$(tput setaf 2)Uninstalling test Runs for testdir=$1 appname=$appname$(tpu
 if [[ -d "$TOP"/builds/test ]]
 then
     if [[ -n "$appname" ]] && [[ -f "$TOP"/builds/test/"$appname"/test ]]
-    then "$TOP"/builds/test/"$appname"/test down --target=${LUNCHPAIL_TARGET:-kubernetes} -v
+    then "$TOP"/builds/test/"$appname"/test down --target=${LUNCHPAIL_TARGET:-kubernetes} --verbose=${VERBOSE:=false}
     else
         for dir in $(ls -t "$TOP"/builds/test)
         do
             if [ -f "$TOP"/builds/test/"$dir"/test ]
-            then "$TOP"/builds/test/"$dir"/test down --target=${LUNCHPAIL_TARGET:-kubernetes} -v &
+            then "$TOP"/builds/test/"$dir"/test down --target=${LUNCHPAIL_TARGET:-kubernetes} --verbose=${VERBOSE:=false} &
             fi
         done
 

--- a/tests/bin/up.sh
+++ b/tests/bin/up.sh
@@ -20,14 +20,14 @@ then
     # could validate the output files there rather than in the queue
     eval $inputapp $QUEUE --create-cluster --target=${LUNCHPAIL_TARGET:-kubernetes} \
         | $testapp up \
-                   -v \
+                   --verbose=${VERBOSE:-false} \
                    $up_args \
                    --no-redirect \
                    --create-cluster \
                    --target=${LUNCHPAIL_TARGET:-kubernetes}
 else
     eval $testapp up \
-         -v \
+         --verbose=${VERBOSE:-false} \
          $up_args \
          $QUEUE \
          --create-cluster \


### PR DESCRIPTION
Also:
- use `pip install -q` unless verbose
- use `pip install --no-cache-dir` in kubernetes
- run non-verbose by default