### PR TITLE
fix: pin pydantic==2.9.2 to fix doc-chunk test failures

### DIFF
--- a/tests/tests/python-language-doc-chunk/pail/data/requirements.txt
+++ b/tests/tests/python-language-doc-chunk/pail/data/requirements.txt
@@ -1,6 +1,9 @@
 docling-core==1.3.0
 llama-index-core>=0.11.0,<0.12.0
 
+# sigh. see https://github.com/run-llama/llama_index/issues/17016
+pydantic==2.9.2
+
 # we can probably update to 18+, but we will have to re-generate expected output as pyarrow 18 seems to have resulted in a binary format change
 pyarrow<18
 


### PR DESCRIPTION
see https://github.com/run-llama/llama_index/issues/17016