### PR TITLE
refactor: remove llir.Component as interface. use just llir.ShellComponent struct directly

### DIFF
--- a/pkg/be/ibmcloud/create.go
+++ b/pkg/be/ibmcloud/create.go
@@ -51,7 +51,7 @@ func (i *intCounter) inc() {
 	i.lock.Unlock()
 }
 
-func createInstance(vpcService *vpcv1.VpcV1, name string, ir llir.LLIR, c llir.Component, resourceGroupID string, vpcID string, keyID string, zone string, profile string, subnetID string, secGroupID string, imageID string, namespace string, copts llir.Options) (*vpcv1.Instance, error) {
+func createInstance(vpcService *vpcv1.VpcV1, name string, ir llir.LLIR, c llir.ShellComponent, resourceGroupID string, vpcID string, keyID string, zone string, profile string, subnetID string, secGroupID string, imageID string, namespace string, copts llir.Options) (*vpcv1.Instance, error) {
 	networkInterfacePrototypeModel := &vpcv1.NetworkInterfacePrototype{
 		Name: &name,
 		Subnet: &vpcv1.SubnetIdentityByID{

--- a/pkg/be/kubernetes/marshal.go
+++ b/pkg/be/kubernetes/marshal.go
@@ -1,8 +1,6 @@
 package kubernetes
 
 import (
-	"fmt"
-
 	"lunchpail.io/pkg/be/kubernetes/common"
 	"lunchpail.io/pkg/be/kubernetes/shell"
 	"lunchpail.io/pkg/ir/llir"
@@ -10,13 +8,8 @@ import (
 )
 
 // Marshal one component.
-func marshalComponent(ir llir.LLIR, c llir.Component, namespace string, opts common.Options) (string, error) {
-	switch cc := c.(type) {
-	case llir.ShellComponent:
-		return shell.Template(ir, cc, namespace, opts)
-	}
-
-	return "", fmt.Errorf("Unsupported component type")
+func marshalComponent(ir llir.LLIR, c llir.ShellComponent, namespace string, opts common.Options) (string, error) {
+	return shell.Template(ir, c, namespace, opts)
 }
 
 // Marshal all components, including the common resources needed to
@@ -52,7 +45,7 @@ func (backend Backend) DryRun(ir llir.LLIR, copts llir.Options) (string, error) 
 
 // marshal resources for this component, including common resources
 // needed to make it function on its own in a cluster.
-func MarshalComponentAsStandalone(ir llir.LLIR, c llir.Component, namespace string, opts common.Options) (string, error) {
+func MarshalComponentAsStandalone(ir llir.LLIR, c llir.ShellComponent, namespace string, opts common.Options) (string, error) {
 	yamls, err := common.MarshalCommonResources(ir, namespace, opts)
 	if err != nil {
 		return "", err

--- a/pkg/be/local/ok.go
+++ b/pkg/be/local/ok.go
@@ -21,13 +21,8 @@ func (backend Backend) IsCompatible(ir llir.LLIR) error {
 	}
 
 	for _, c := range ir.Components {
-		switch cc := c.(type) {
-		case llir.ShellComponent:
-			if err := shell.IsCompatible(cc); err != nil {
-				return err
-			}
-		default:
-			return fmt.Errorf("Unable to target a non-shell component '%v' to the local backend", c.C())
+		if err := shell.IsCompatible(c); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/be/local/shell/pipe.go
+++ b/pkg/be/local/shell/pipe.go
@@ -11,7 +11,7 @@ import (
 	"lunchpail.io/pkg/lunchpail"
 )
 
-func pipe(mkpipe func() (io.ReadCloser, error), out io.Writer, teefile string, c llir.Component) (chan struct{}, error) {
+func pipe(mkpipe func() (io.ReadCloser, error), out io.Writer, teefile string, c llir.ShellComponent) (chan struct{}, error) {
 	p, err := mkpipe()
 	if err != nil {
 		return nil, err

--- a/pkg/be/local/spawn.go
+++ b/pkg/be/local/spawn.go
@@ -2,22 +2,16 @@ package local
 
 import (
 	"context"
-	"fmt"
 
 	"lunchpail.io/pkg/be/local/shell"
 	"lunchpail.io/pkg/build"
 	"lunchpail.io/pkg/ir/llir"
 )
 
-func (backend Backend) spawn(ctx context.Context, c llir.Component, ir llir.LLIR, logdir string, opts build.LogOptions) error {
-	switch cc := c.(type) {
-	case llir.ShellComponent:
-		if cc.RunAsJob {
-			return shell.SpawnJob(ctx, cc, ir, logdir, opts)
-		} else {
-			return shell.Spawn(ctx, cc, ir, logdir, opts)
-		}
+func (backend Backend) spawn(ctx context.Context, c llir.ShellComponent, ir llir.LLIR, logdir string, opts build.LogOptions) error {
+	if c.RunAsJob {
+		return shell.SpawnJob(ctx, c, ir, logdir, opts)
+	} else {
+		return shell.Spawn(ctx, c, ir, logdir, opts)
 	}
-
-	return fmt.Errorf("Unsupported component type")
 }

--- a/pkg/fe/transformer/api/minio/lower.go
+++ b/pkg/fe/transformer/api/minio/lower.go
@@ -8,14 +8,14 @@ import (
 	"lunchpail.io/pkg/lunchpail"
 )
 
-func Lower(buildName string, ctx llir.Context, model hlir.HLIR, opts build.Options) (llir.Component, error) {
+func Lower(buildName string, ctx llir.Context, model hlir.HLIR, opts build.Options) (llir.ShellComponent, bool, error) {
 	if !ctx.Queue.Auto {
-		return nil, nil
+		return llir.ShellComponent{}, false, nil
 	}
 
 	app, err := transpile(ctx)
 	if err != nil {
-		return nil, err
+		return llir.ShellComponent{}, false, err
 	}
 
 	component, err := shell.LowerAsComponent(
@@ -26,5 +26,5 @@ func Lower(buildName string, ctx llir.Context, model hlir.HLIR, opts build.Optio
 		opts,
 	)
 
-	return component, err
+	return component, err == nil, err
 }

--- a/pkg/fe/transformer/api/shell/lower.go
+++ b/pkg/fe/transformer/api/shell/lower.go
@@ -16,11 +16,11 @@ import (
 	"lunchpail.io/pkg/lunchpail"
 )
 
-func Lower(buildName string, ctx llir.Context, app hlir.Application, opts build.Options) (llir.Component, error) {
+func Lower(buildName string, ctx llir.Context, app hlir.Application, opts build.Options) (llir.ShellComponent, error) {
 	return LowerAsComponent(buildName, ctx, app, llir.ShellComponent{Component: lunchpail.WorkersComponent}, opts)
 }
 
-func LowerAsComponent(buildName string, ctx llir.Context, app hlir.Application, component llir.ShellComponent, opts build.Options) (llir.Component, error) {
+func LowerAsComponent(buildName string, ctx llir.Context, app hlir.Application, component llir.ShellComponent, opts build.Options) (llir.ShellComponent, error) {
 	component.Application = app
 	if app.Spec.MinMemory != "" {
 		appBytes, err := humanize.ParseBytes(app.Spec.MinMemory)
@@ -71,9 +71,9 @@ PATH=$($LUNCHPAIL_EXE needs %s %s %s --verbose=%v):$PATH
 			isValid, spec, err := q.SpecFromRcloneRemoteName(dataset.S3.Rclone.RemoteName, "", ctx.Run.RunName, ctx.Queue.Port)
 
 			if err != nil {
-				return nil, err
+				return llir.ShellComponent{}, err
 			} else if !isValid {
-				return nil, fmt.Errorf("Error: invalid or missing rclone config for given remote=%s for Application=%s", dataset.S3.Rclone.RemoteName, app.Metadata.Name)
+				return llir.ShellComponent{}, fmt.Errorf("Error: invalid or missing rclone config for given remote=%s for Application=%s", dataset.S3.Rclone.RemoteName, app.Metadata.Name)
 			}
 
 			// sleep to delay the copy-out, if requested

--- a/pkg/fe/transformer/api/workerpool/lower.go
+++ b/pkg/fe/transformer/api/workerpool/lower.go
@@ -12,7 +12,7 @@ import (
 	"lunchpail.io/pkg/lunchpail"
 )
 
-func Lower(buildName string, ctx llir.Context, app hlir.Application, pool hlir.WorkerPool, opts build.Options) (llir.Component, error) {
+func Lower(buildName string, ctx llir.Context, app hlir.Application, pool hlir.WorkerPool, opts build.Options) (llir.ShellComponent, error) {
 	spec := llir.ShellComponent{Component: lunchpail.WorkersComponent}
 
 	// maybe at some point... we would need to update at least be/local.watchForWorkerPools also to watch for dispatchers?
@@ -46,7 +46,7 @@ func Lower(buildName string, ctx llir.Context, app hlir.Application, pool hlir.W
 
 	startupDelay, err := parseHumanTime(pool.Spec.StartupDelay)
 	if err != nil {
-		return nil, err
+		return llir.ShellComponent{}, err
 	}
 	if app.Spec.Env == nil {
 		app.Spec.Env = make(map[string]string)

--- a/pkg/fe/transformer/api/workerpool/lowerall.go
+++ b/pkg/fe/transformer/api/workerpool/lowerall.go
@@ -9,8 +9,8 @@ import (
 )
 
 // HLIR -> LLIR for []hlir.WorkerPool
-func LowerAll(buildName string, ctx llir.Context, model hlir.HLIR, opts build.Options) ([]llir.Component, error) {
-	components := []llir.Component{}
+func LowerAll(buildName string, ctx llir.Context, model hlir.HLIR, opts build.Options) ([]llir.ShellComponent, error) {
+	components := []llir.ShellComponent{}
 
 	app, found := model.GetWorkerApplication()
 	if !found {

--- a/pkg/fe/transformer/api/workstealer/lower.go
+++ b/pkg/fe/transformer/api/workstealer/lower.go
@@ -7,10 +7,10 @@ import (
 	"lunchpail.io/pkg/lunchpail"
 )
 
-func Lower(buildName string, ctx llir.Context, opts build.Options) (llir.Component, error) {
+func Lower(buildName string, ctx llir.Context, opts build.Options) (llir.ShellComponent, error) {
 	app, err := transpile(ctx, *opts.Log)
 	if err != nil {
-		return nil, err
+		return llir.ShellComponent{}, err
 	}
 
 	return shell.LowerAsComponent(

--- a/pkg/fe/transformer/application.go
+++ b/pkg/fe/transformer/application.go
@@ -9,8 +9,8 @@ import (
 )
 
 // HLIR -> LLIR for []hlir.Application
-func lowerApplications(buildName string, ctx llir.Context, model hlir.HLIR, opts build.Options) ([]llir.Component, error) {
-	components := []llir.Component{}
+func lowerApplications(buildName string, ctx llir.Context, model hlir.HLIR, opts build.Options) ([]llir.ShellComponent, error) {
+	components := []llir.ShellComponent{}
 
 	if ctx.Run.Step == 0 && workstealer.IsNeeded(model) {
 		// Note, the actual worker resources will be dealt

--- a/pkg/fe/transformer/lower.go
+++ b/pkg/fe/transformer/lower.go
@@ -14,12 +14,10 @@ import (
 func Lower(buildName string, model hlir.HLIR, ctx llir.Context, opts build.Options) (llir.LLIR, error) {
 	ir := llir.LLIR{AppName: buildName, Context: ctx}
 
-	minio, err := minio.Lower(buildName, ctx, model, opts)
-	if err != nil {
+	if minio, minioOk, err := minio.Lower(buildName, ctx, model, opts); err != nil {
 		return llir.LLIR{}, err
-	}
-	if minio != nil {
-		ir.Components = slices.Concat([]llir.Component{minio})
+	} else if minioOk {
+		ir.Components = slices.Concat([]llir.ShellComponent{minio})
 	}
 
 	apps, err := lowerApplications(buildName, ctx, model, opts)

--- a/pkg/ir/llir/llir.go
+++ b/pkg/ir/llir/llir.go
@@ -1,16 +1,5 @@
 package llir
 
-import "lunchpail.io/pkg/lunchpail"
-
-// One Component for WorkStealer, one for Dispatcher, and each per WorkerPool
-type Component interface {
-	C() lunchpail.Component
-
-	Workers() int
-
-	SetWorkers(w int) Component
-}
-
 type LLIR struct {
 	AppName string
 
@@ -22,16 +11,13 @@ type LLIR struct {
 	AppProvidedKubernetesResources string
 
 	// One Component per WorkerPool, one for WorkerStealer, etc.
-	Components []Component
+	Components []ShellComponent
 }
 
 func (ir LLIR) HasDispatcher() bool {
 	for _, c := range ir.Components {
-		switch cc := c.(type) {
-		case ShellComponent:
-			if cc.Application.Spec.IsDispatcher {
-				return true
-			}
+		if c.Application.Spec.IsDispatcher {
+			return true
 		}
 	}
 

--- a/pkg/ir/llir/shell.go
+++ b/pkg/ir/llir/shell.go
@@ -5,6 +5,7 @@ import (
 	"lunchpail.io/pkg/lunchpail"
 )
 
+// One Component for WorkStealer, one for Dispatcher, and each per WorkerPool
 type ShellComponent struct {
 	hlir.Application
 
@@ -37,7 +38,7 @@ func (c ShellComponent) Workers() int {
 	return c.InitialWorkers
 }
 
-func (c ShellComponent) SetWorkers(w int) Component {
+func (c ShellComponent) SetWorkers(w int) ShellComponent {
 	c.InitialWorkers = w
 	return c // FIXME
 }


### PR DESCRIPTION
1. helps with marshaling
2. removes untested code paths (llir.Component not a llir.ShellComponent)