### PR TITLE
feat: support passing through gzipped files, uncompressing them on the worker side

### DIFF
--- a/cmd/options/build.go
+++ b/cmd/options/build.go
@@ -38,6 +38,7 @@ func AddBuildOptions(cmd *cobra.Command) (*build.Options, error) {
 	cmd.Flags().StringToStringVarP(&options.Env, "env", "e", options.Env, "Set environment variables")
 
 	cmd.Flags().IntVar(&options.Pack, "pack", options.Pack, "Run k concurrent tasks; if k=0 and machine has N cores, then k=N")
+	cmd.Flags().BoolVarP(&options.Gunzip, "gunzip", "z", options.Gunzip, "Gunzip inputs before passing them to the worker logic")
 
 	AddTargetOptionsTo(cmd, &options)
 	AddLogOptionsTo(cmd, &options)

--- a/cmd/subcommands/component/worker/run.go
+++ b/cmd/subcommands/component/worker/run.go
@@ -40,6 +40,9 @@ func Run() *cobra.Command {
 	var startupDelay int
 	cmd.Flags().IntVar(&startupDelay, "delay", 0, "Delay (in seconds) before engaging in any work")
 
+	var gunzip bool
+	cmd.Flags().BoolVarP(&gunzip, "gunzip", "z", gunzip, "Gunzip inputs before passing them to the worker logic")
+
 	ccOpts := options.AddCallingConventionOptions(cmd)
 	logOpts := options.AddLogOptions(cmd)
 
@@ -55,6 +58,7 @@ func Run() *cobra.Command {
 
 		return worker.Run(context.Background(), args, worker.Options{
 			Pack:              pack,
+			Gunzip:            gunzip,
 			CallingConvention: ccOpts.CallingConvention,
 			StartupDelay:      startupDelay,
 			PollingInterval:   pollingInterval,

--- a/demos/pipelines/run.sh
+++ b/demos/pipelines/run.sh
@@ -3,16 +3,16 @@
 set -eo pipefail
 
 SCRIPTDIR=$(cd $(dirname "$0") && pwd)
-TOP="$SCRIPTDIR"/..
+TOP="$SCRIPTDIR"/../..
 
 lp=/tmp/lunchpail
 if [ ! -e $lp ]
 then "$TOP"/hack/setup/cli.sh $lp
 fi
 
-IN1=$(mktemp)
-echo "1" > $IN1
-trap "rm -f $IN1 $fail $add1b $add1c $add1d" EXIT
+INGZIP=$(mktemp)
+echo "1" | gzip > $INGZIP
+trap "rm -f $INGZIP" EXIT
 
 export LUNCHPAIL_NAME="pipeline-demo"
 export LUNCHPAIL_TARGET=${LUNCHPAIL_TARGET:-local}
@@ -84,5 +84,5 @@ else stepk="$stepl" # if we are not intentionally testing kubernetes, then use l
 fi
 
 echo "Launching pipeline"
-$stepl <(echo in1) <(echo in2) <(echo in3) <(echo in4) <(echo in5) <(echo in6) <(echo in7) <(echo in8) <(echo in9) <(echo in10) <(echo in11) <(echo in12) <(echo in13) <(echo in14) <(echo in15) <(echo in16) \
+$stepl --gunzip $INGZIP <(echo in2) <(echo in3) <(echo in4) <(echo in5) <(echo in6) <(echo in7) <(echo in8) <(echo in9) <(echo in10) <(echo in11) <(echo in12) <(echo in13) <(echo in14) <(echo in15) <(echo in16) \
     | $stepk | $stepl | $stepk | $stepl | $stepl | $stepl | $stepl

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -43,6 +43,9 @@ type Options struct {
 
 	// Run k concurrent tasks; if k=0 and machine has N cores, then k=N
 	Pack int `yaml:",omitempty"`
+
+	// Gunzip inputs before passing them to the worker logic
+	Gunzip bool `yaml:",omitempty"`
 }
 
 //go:embed buildOptions.json

--- a/pkg/fe/transformer/api/workerpool/lower.go
+++ b/pkg/fe/transformer/api/workerpool/lower.go
@@ -52,7 +52,7 @@ func Lower(buildName string, ctx llir.Context, app hlir.Application, pool hlir.W
 		app.Spec.Env = make(map[string]string)
 	}
 
-	queueArgs := fmt.Sprintf("--step %d --pool %s --worker $LUNCHPAIL_POD_NAME --verbose=%v --debug=%v ",
+	queueArgs := fmt.Sprintf("--step %d --pool %s --worker $LUNCHPAIL_POD_NAME --verbose=%v --debug=%v",
 		ctx.Run.Step,
 		poolName,
 		opts.Log.Verbose,
@@ -68,9 +68,10 @@ func Lower(buildName string, ctx llir.Context, app hlir.Application, pool hlir.W
 	}
 
 	app.Spec.Command = fmt.Sprintf(`trap "$LUNCHPAIL_EXE component worker prestop %s" EXIT
-$LUNCHPAIL_EXE component worker run --pack %d --delay %d --calling-convention %v %s -- %s`,
+$LUNCHPAIL_EXE component worker run --pack %d --gunzip=%v --delay %d --calling-convention %v %s -- %s`,
 		queueArgs,
 		opts.Pack,
+		opts.Gunzip,
 		startupDelay,
 		callingConvention,
 		queueArgs,

--- a/pkg/runtime/worker/options.go
+++ b/pkg/runtime/worker/options.go
@@ -10,6 +10,9 @@ type Options struct {
 	// Run k concurrent tasks; if k=0 and machine has N cores, then k=N
 	Pack int
 
+	// Gunzip inputs before passing them to the worker logic
+	Gunzip bool
+
 	hlir.CallingConvention
 	queue.RunContext
 	StartupDelay    int

--- a/tests/tests/python-code-code-quality/post.sh
+++ b/tests/tests/python-code-code-quality/post.sh
@@ -25,5 +25,5 @@ function validate {
     rm -f "$actual"
 }
 
-validate task.1.parquet "$DATA"/expected/sample_1.parquet.gz
-validate task.2.parquet "$DATA"/expected/sample_2.parquet.gz
+validate sample_1.parquet "$DATA"/expected/sample_1.parquet.gz
+validate sample_2.parquet "$DATA"/expected/sample_2.parquet.gz

--- a/tests/tests/python-code-code-quality/settings.sh
+++ b/tests/tests/python-code-code-quality/settings.sh
@@ -6,4 +6,4 @@ NUM_DESIRED_OUTPUTS=0
 # the default is --yaml. we don't want that
 source_from=" "
 
-up_args='<(gunzip -c "$TEST_PATH"/pail/test-data/input/sample_1.parquet.gz) <(gunzip -c "$TEST_PATH"/pail/test-data/input/sample_2.parquet.gz)'
+up_args='--gunzip "$TEST_PATH"/pail/test-data/input/sample_1.parquet.gz "$TEST_PATH"/pail/test-data/input/sample_2.parquet.gz'


### PR DESCRIPTION
Advantages:
- less network traffic
- cosmetically, for demos we can avoid the use of named pipes `<(gunzip -c input.gz)`

Disadvantages:
- extra cpu consumption on the worker side
- if using `files` calling convention, extra disk space consumption on the worker (to contain the gunzipped file *and* the gzipped file)

Test coverage in python-code-code-quality

TODOs:
- uncompress while downloading the task, rather than downloading and then gunzipping (this would eliminate the second disadvantage)
- update the rest of the python-* examples to use --gunzip rather than named pipes