### PR TITLE
fix: switch some python:3 images to use the -slim variant

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,8 @@ jobs:
         key: ${{ runner.os }}-minio
     - name: Build Lunchpail CLI
       run: ./hack/setup/cli.sh /tmp/lunchpail
+    - name: Hack apt
+      run: sudo apt install -y libmagic1
 
     # we will also be testing installing kind, so we don't want to do
     # this as part of the github action workflow

--- a/demos/data-prep-kit/code/header-cleanser/image
+++ b/demos/data-prep-kit/code/header-cleanser/image
@@ -1,1 +1,1 @@
-docker.io/python:3.10
+docker.io/python:3.10-slim

--- a/demos/data-prep-kit/code/header-cleanser/requirements.txt
+++ b/demos/data-prep-kit/code/header-cleanser/requirements.txt
@@ -1,6 +1,5 @@
 scancode-toolkit-mini
+python-magic
+python-magic-bin
 
-# we can probably update to 18+, but we will have to re-generate expected output as pyarrow 18 seems to have resulted in a binary format change
-pyarrow<17
-
-setuptools
+pyarrow

--- a/demos/data-prep-kit/language/pdf2parquet/image
+++ b/demos/data-prep-kit/language/pdf2parquet/image
@@ -1,1 +1,1 @@
-docker.io/python:3.11
+docker.io/python:3.11-slim

--- a/demos/data-prep-kit/language/pii-redactor/image
+++ b/demos/data-prep-kit/language/pii-redactor/image
@@ -1,1 +1,1 @@
-docker.io/python:3.10
+docker.io/python:3.10-slim

--- a/demos/data-prep-kit/language/text-encoder/image
+++ b/demos/data-prep-kit/language/text-encoder/image
@@ -1,1 +1,1 @@
-docker.io/python:3.12
+docker.io/python:3.12-slim

--- a/demos/data-prep-kit/universal/doc-id/image
+++ b/demos/data-prep-kit/universal/doc-id/image
@@ -1,1 +1,1 @@
-docker.io/python:3.12
+docker.io/python:3.12-slim

--- a/demos/data-prep-kit/universal/ededup/image
+++ b/demos/data-prep-kit/universal/ededup/image
@@ -1,1 +1,1 @@
-docker.io/python:3.12
+docker.io/python:3.12-slim

--- a/demos/data-prep-kit/universal/tokenization/image
+++ b/demos/data-prep-kit/universal/tokenization/image
@@ -1,1 +1,1 @@
-docker.io/python:3.12
+docker.io/python:3.12-slim

--- a/pkg/fe/builder/overlay/filesystem.go
+++ b/pkg/fe/builder/overlay/filesystem.go
@@ -163,7 +163,7 @@ func (b filesystemBuilder) addCode(spec *hlir.Spec, sourcePath string) (err erro
 				maybeImage = "docker.io/alpine:3"
 			case "main.py":
 				maybeCommand = "python3 main.py"
-				maybeImage = "docker.io/python:3.12"
+				maybeImage = "docker.io/python:3.12-slim"
 			}
 			return nil
 		})

--- a/pkg/runtime/needs/install_requirements.go
+++ b/pkg/runtime/needs/install_requirements.go
@@ -86,11 +86,11 @@ func requirementsInstall(ctx context.Context, version, requirements string, verb
 	}
 
 	cmdline := fmt.Sprintf(`python%s -m venv %s
-source %s/bin/activate
+. %s/bin/activate
 if ! which pip%s > /dev/null; then python%s -m pip install pip %s; fi
 pip%s install %s %s -r %s %s 1>&2`, version, venvPath, venvPath, version, version, verboseFlag, version, nocache, quiet, reqmtsFile.Name(), verboseFlag)
 
-	cmd := exec.CommandContext(ctx, "/bin/bash", "-c", cmdline)
+	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", cmdline)
 	cmd.Dir = filepath.Dir(venvPath)
 	cmd.Stdout = os.Stderr // Stderr so as not to collide with `lunchpail needs` stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
Note: using the `-alpine` variant would be problematic as e.g. pyarrow only distributes wheels for glibc. https://github.com/apache/arrow/issues/18036